### PR TITLE
Start background service from extension

### DIFF
--- a/PatternPal/PatternPal.Extension/ExtensionWindow.cs
+++ b/PatternPal/PatternPal.Extension/ExtensionWindow.cs
@@ -4,6 +4,8 @@ using PatternPal.Extension.Stores;
 using PatternPal.Extension.ViewModels;
 using Microsoft.VisualStudio.Shell;
 
+using PatternPal.Extension.Grpc;
+
 namespace PatternPal.Extension
 {
     /// <summary>
@@ -35,8 +37,10 @@ namespace PatternPal.Extension
             Content = new ExtensionWindowControl {DataContext = new MainViewModel(navigationStore)};
         }
 
-        internal static void Main()
+        protected override void OnClose()
         {
+            GrpcBackgroundServiceHelper.KillBackgroundService();
+            base.OnClose();
         }
     }
 }

--- a/PatternPal/PatternPal.Extension/Grpc/GrpcBackgroundServiceHelper.cs
+++ b/PatternPal/PatternPal.Extension/Grpc/GrpcBackgroundServiceHelper.cs
@@ -1,0 +1,43 @@
+﻿#region
+
+using System;
+using System.Diagnostics;
+using System.IO;
+
+using EnvDTE;
+
+using Process = System.Diagnostics.Process;
+
+#endregion
+
+namespace PatternPal.Extension.Grpc
+{
+    internal static class GrpcBackgroundServiceHelper
+    {
+        private static Process _backgroundService;
+
+        internal static void StartBackgroundService(
+            DTE dte)
+        {
+            string backgroundServicePath = Path.Combine(
+                Directory.GetCurrentDirectory(),
+                "PatternPal",
+                "PatternPal.exe");
+            _backgroundService = Process.Start(
+                new ProcessStartInfo(backgroundServicePath)
+                {
+                    CreateNoWindow = true, UseShellExecute = false,
+                });
+
+            if (null == _backgroundService)
+            {
+                throw new Exception("Unable to start background service");
+            }
+        }
+
+        internal static void KillBackgroundService()
+        {
+            _backgroundService.Kill();
+        }
+    }
+}

--- a/PatternPal/PatternPal.Extension/PatternPal.Extension.csproj
+++ b/PatternPal/PatternPal.Extension/PatternPal.Extension.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Commands\BackCommand.cs" />
     <Compile Include="Commands\LoggingApiClient.cs" />
     <Compile Include="Commands\NavigateCommand.cs" />
+    <Compile Include="Grpc\GrpcBackgroundServiceHelper.cs" />
     <Compile Include="Grpc\GrpcChannelHelper.cs" />
     <Compile Include="Model\Action.cs" />
     <Compile Include="Model\InstructionState.cs" />
@@ -275,6 +276,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="PatternPal\**\*.*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>

--- a/PatternPal/PatternPal.Extension/PatternPal.ExtensionPackage.cs
+++ b/PatternPal/PatternPal.Extension/PatternPal.ExtensionPackage.cs
@@ -71,6 +71,8 @@ namespace PatternPal.Extension
         protected override async Task InitializeAsync(CancellationToken cancellationToken,
             IProgress<ServiceProgressData> progress)
         {
+            // NOTE: This code is never called!
+
             // When initialized asynchronously, the current thread may be a background thread at this point.
             // Do any initialization that requires the UI thread after switching to the UI thread.
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);

--- a/PatternPal/PatternPal/Services/PatternPalService.cs
+++ b/PatternPal/PatternPal/Services/PatternPalService.cs
@@ -75,7 +75,9 @@ public class PatternPalService : Protos.PatternPal.PatternPalBase
 
             RecognizerResult r = new RecognizerResult
                                  {
-                                     DetectedPattern = result.Pattern.Name, ClassName = result.EntityNode.GetFullName(), Result = res,
+                                     DetectedPattern = result.Pattern.Name,
+                                     ClassName = result.EntityNode.GetFullName(),
+                                     Result = res,
                                  };
             responseStream.WriteAsync(r);
         }
@@ -88,7 +90,10 @@ public class PatternPalService : Protos.PatternPal.PatternPalBase
     {
         CheckResult newCheckResult = new()
                                      {
-                                         FeedbackType = (FeedbackType)((int)checkResult.GetFeedbackType() + 1), Hidden = checkResult.IsHidden, Score = checkResult.GetScore(), FeedbackMessage = ResourceUtils.ResultToString(checkResult),
+                                         FeedbackType = (FeedbackType)((int)checkResult.GetFeedbackType() + 1),
+                                         Hidden = checkResult.IsHidden,
+                                         Score = checkResult.GetScore(),
+                                         FeedbackMessage = ResourceUtils.ResultToString(checkResult),
                                      };
         foreach (ICheckResult childCheckResult in checkResult.GetChildFeedback())
         {

--- a/PatternPal/PatternPal/Services/PatternPalService.cs
+++ b/PatternPal/PatternPal/Services/PatternPalService.cs
@@ -1,15 +1,16 @@
-﻿using PatternPal.CommonResources;
+﻿#region
+
+using PatternPal.CommonResources;
+
+#endregion
 
 namespace PatternPal.Services;
 
 public class PatternPalService : Protos.PatternPal.PatternPalBase
 {
-
-
-
     public override Task Recognize(
         RecognizeRequest request,
-        IServerStreamWriter<RecognizerResult> responseStream,
+        IServerStreamWriter< RecognizerResult > responseStream,
         ServerCallContext context)
     {
         string pathFile = request.File;
@@ -29,10 +30,10 @@ public class PatternPalService : Protos.PatternPal.PatternPalBase
             //TODO programming language is not compatible add a feedback message for project check for .csproj?
         }
 
-        List<string> files;
+        List< string > files;
         // Return all the .cs files (and in all subdirectories)
         // Does not include files part of project but not in directory
-        if (string.IsNullOrEmpty(pathProject))
+        if (!string.IsNullOrEmpty(pathProject))
         {
             files = Directory.GetFiles(
                 Path.GetDirectoryName(pathProject),
@@ -41,13 +42,16 @@ public class PatternPalService : Protos.PatternPal.PatternPalBase
         }
         else
         {
-            files = new() { request.File };
+            files = new List< string >
+                    {
+                        request.File
+                    };
         }
 
         RecognizerRunner runner = new();
         runner.CreateGraph(files);
 
-        List<DesignPattern> patterns = new();
+        List< DesignPattern > patterns = new();
         foreach (Recognizer recognizer in request.Recognizers)
         {
             if (recognizer == Recognizer.Unknown)
@@ -61,20 +65,18 @@ public class PatternPalService : Protos.PatternPal.PatternPalBase
         foreach (RecognitionResult result in runner.Run(patterns))
         {
             Result res = new()
-            {
-                Score = result.Result.GetScore()
-            };
+                         {
+                             Score = result.Result.GetScore()
+                         };
             foreach (ICheckResult checkResult in result.Result.GetResults())
             {
                 res.Results.Add(CreateCheckResult(checkResult));
             }
 
             RecognizerResult r = new RecognizerResult
-            {
-                DetectedPattern = result.Pattern.Name,
-                ClassName = result.EntityNode.GetFullName(),
-                Result = res,
-            };
+                                 {
+                                     DetectedPattern = result.Pattern.Name, ClassName = result.EntityNode.GetFullName(), Result = res,
+                                 };
             responseStream.WriteAsync(r);
         }
 
@@ -85,12 +87,9 @@ public class PatternPalService : Protos.PatternPal.PatternPalBase
         ICheckResult checkResult)
     {
         CheckResult newCheckResult = new()
-        {
-            FeedbackType = (FeedbackType)((int)checkResult.GetFeedbackType() + 1),
-            Hidden = checkResult.IsHidden,
-            Score = checkResult.GetScore(),
-            FeedbackMessage = ResourceUtils.ResultToString(checkResult),
-        };
+                                     {
+                                         FeedbackType = (FeedbackType)((int)checkResult.GetFeedbackType() + 1), Hidden = checkResult.IsHidden, Score = checkResult.GetScore(), FeedbackMessage = ResourceUtils.ResultToString(checkResult),
+                                     };
         foreach (ICheckResult childCheckResult in checkResult.GetChildFeedback())
         {
             newCheckResult.ChildFeedback.Add(CreateCheckResult(childCheckResult));


### PR DESCRIPTION
Unfortunately, starting the background service as a child process doesn't result in it being killed along with the parent process, which is why we need to kill it ourselves before VS is closed. This could definitely be improved, and there is still an issue if the code to kill the background service isn't run for some reason. Perhaps we could check whether the background service is already running before starting a new instance.

For now, this seems good enough.