### PR TITLE
BS+Ext: Fix show all results button

### DIFF
--- a/PatternPal/PatternPal.Extension/Views/DetectorView.xaml
+++ b/PatternPal/PatternPal.Extension/Views/DetectorView.xaml
@@ -177,9 +177,9 @@
                            Foreground="#4496F3" VerticalAlignment="Top" FontSize="15" FontWeight="Bold"
                            Margin="5,5,5,0" />
             </StackPanel>
-            <CheckBox Margin="0 0 5 0" x:Name="CheckSwitch" DockPanel.Dock="Right" Content="Show All" IsChecked="True"
-                      FlowDirection="RightToLeft" Style="{DynamicResource CheckboxStyle}" Checked="CheckSwitch_Checked"
-                      Unchecked="CheckSwitch_Unchecked" />
+            <CheckBox Margin="0 0 5 0" x:Name="ShowAllCheckBox" DockPanel.Dock="Right" Content="Show All" IsChecked="True"
+                      FlowDirection="RightToLeft" Style="{DynamicResource CheckboxStyle}" Checked="ShowAllCheckBox_OnChecked"
+                      Unchecked="ShowAllCheckBox_OnUnchecked" />
         </DockPanel>
         <TextBlock Grid.Row="7" x:Name="SummaryControl" TextWrapping="Wrap" Margin="20,8,20,8" MaxWidth="450" HorizontalAlignment="Left"/>
         <usercontrol:ExpanderResults x:Name="ExpanderResults" Grid.Row="8" Margin="20,0,20,0" />

--- a/PatternPal/PatternPal.Extension/Views/DetectorView.xaml.cs
+++ b/PatternPal/PatternPal.Extension/Views/DetectorView.xaml.cs
@@ -237,6 +237,8 @@ namespace PatternPal.Extension.Views
                 request.Recognizers.Add(designPatternViewModel.Recognizer);
             }
 
+            request.ShowAllResults = !(ShowAllCheckBox.IsChecked.HasValue && ShowAllCheckBox.IsChecked.Value);
+
             IAsyncStreamReader< RecognizeResponse > responseStream = GrpcHelper.RecognizerClient.Recognize(request).ResponseStream;
 
             IList< RecognizeResult > results = new List< RecognizeResult >();
@@ -247,37 +249,7 @@ namespace PatternPal.Extension.Views
 
             CreateResultViewModels(results);
             SummaryControl.Text = "Recognizer is finished";
-            ResetUI();
-        }
 
-        private void CheckSwitch_Checked(
-            object sender,
-            RoutedEventArgs e)
-        {
-            if (Results == null)
-            {
-                return;
-            }
-
-            //CreateResultViewModels(Results);
-        }
-
-        private void CheckSwitch_Unchecked(
-            object sender,
-            RoutedEventArgs e)
-        {
-            if (Results == null)
-            {
-                return;
-            }
-
-            List< RecognizeResult > results = Results.Where(x => x.Score >= 80).ToList();
-            //CreateResultViewModels(results);
-        }
-
-        private void ResetUI()
-        {
-            //statusBar.Value = 0;
             Loading = false;
             ProgressStatusBlock.Text = "";
         }
@@ -360,5 +332,29 @@ namespace PatternPal.Extension.Views
         }
 
         #endregion
+
+        private void ShowAllCheckBox_OnChecked(
+            object sender,
+            RoutedEventArgs e)
+        {
+            if (Results == null)
+            {
+                return;
+            }
+
+            CreateResultViewModels(Results);
+        }
+
+        private void ShowAllCheckBox_OnUnchecked(
+            object sender,
+            RoutedEventArgs e)
+        {
+            if (Results == null)
+            {
+                return;
+            }
+
+            CreateResultViewModels(Results);
+        }
     }
 }

--- a/PatternPal/PatternPal.Extension/Views/DetectorView.xaml.cs
+++ b/PatternPal/PatternPal.Extension/Views/DetectorView.xaml.cs
@@ -203,6 +203,11 @@ namespace PatternPal.Extension.Views
 
         private async Task Analyse()
         {
+            if (null == Dte)
+            {
+                return;
+            }
+
             RecognizeRequest request = new RecognizeRequest();
 
             // TODO CV: Handle error cases
@@ -337,24 +342,14 @@ namespace PatternPal.Extension.Views
             object sender,
             RoutedEventArgs e)
         {
-            if (Results == null)
-            {
-                return;
-            }
-
-            CreateResultViewModels(Results);
+            Analyse();
         }
 
         private void ShowAllCheckBox_OnUnchecked(
             object sender,
             RoutedEventArgs e)
         {
-            if (Results == null)
-            {
-                return;
-            }
-
-            CreateResultViewModels(Results);
+            Analyse();
         }
     }
 }

--- a/Protos/recognizer.proto
+++ b/Protos/recognizer.proto
@@ -26,6 +26,9 @@ message RecognizeRequest {
 
     // List of recognizers which should be run.
     repeated patternpal.Recognizer recognizers = 3;
+
+    // Whether to show all results or just those above a threshold determined by the backend.
+    bool show_all_results = 4;
 }
 
 // Recognize response message.


### PR DESCRIPTION
This patch moves the show all functionality to the backend. The only difference with the previous behavior is that the show all button only takes effect on the next analyze call, it doesn't refresh the results.