### PR TITLE
BS+Ext: Get supported recognizers from backend

### DIFF
--- a/PatternPal/PatternPal.Extension/Views/DetectorView.xaml.cs
+++ b/PatternPal/PatternPal.Extension/Views/DetectorView.xaml.cs
@@ -147,9 +147,10 @@ namespace PatternPal.Extension.Views
         private void AddViewModels()
         {
             ViewModels = new List< DesignPatternViewModel >();
-            foreach (object value in Enum.GetValues(typeof( Recognizer )))
+            GetSupportedRecognizersResponse response = GrpcHelper.RecognizerClient.GetSupportedRecognizers(new GetSupportedRecognizersRequest());
+            foreach (Recognizer recognizer in response.Recognizers)
             {
-                ViewModels.Add(new DesignPatternViewModel((Recognizer)value));
+                ViewModels.Add(new DesignPatternViewModel(recognizer));
             }
 
             PatternCheckbox.listBox.DataContext = ViewModels;

--- a/PatternPal/PatternPal/Services/RecognizerService.cs
+++ b/PatternPal/PatternPal/Services/RecognizerService.cs
@@ -4,6 +4,31 @@ public class RecognizerService : Protos.RecognizerService.RecognizerServiceBase
 {
     private const int SCORE_THRESHOLD_FOR_SHOW_ALL = 80;
 
+    public override Task< GetSupportedRecognizersResponse > GetSupportedRecognizers(
+        GetSupportedRecognizersRequest request,
+        ServerCallContext context)
+    {
+        GetSupportedRecognizersResponse response = new();
+
+        bool initialValue = true;
+        foreach (object value in Enum.GetValues(typeof( Recognizer )))
+        {
+            // Skip the first value of the enum. This value is required by the Protocol Buffer
+            // spec, but it shouldn't be used directly, because it's impossible to know whether
+            // the value was set to the default value, or no value was set (because when no
+            // value is set, the default value is used).
+            if (initialValue)
+            {
+                initialValue = false;
+                continue;
+            }
+
+            response.Recognizers.Add((Recognizer)value);
+        }
+
+        return Task.FromResult(response);
+    }
+
     public override Task Recognize(
         RecognizeRequest request,
         IServerStreamWriter< RecognizeResponse > responseStream,

--- a/Protos/recognizer.proto
+++ b/Protos/recognizer.proto
@@ -8,9 +8,23 @@ option csharp_namespace = "PatternPal.Protos";
 
 // The PatternPal recognizer API exposed by the background service.
 service RecognizerService {
+    // Gets the supported recognizers which can be selected by the user.
+    rpc GetSupportedRecognizers (GetSupportedRecognizersRequest)
+        returns (GetSupportedRecognizersResponse);
+
     // Runs the specified recognizer(s) on the given file(s)/project, and returns a result for each
     // class in which a design pattern is detected.
     rpc Recognize (RecognizeRequest) returns (stream RecognizeResponse);
+}
+
+// GetSupportedRecognizers request message.
+message GetSupportedRecognizersRequest {
+}
+
+// GetSupportedRecognizers response message.
+message GetSupportedRecognizersResponse {
+    // List of recognizers which are supported.
+    repeated patternpal.Recognizer recognizers = 1;
 }
 
 // Recognize request message.


### PR DESCRIPTION
Gets the supported recognizers from the backend. This is done in order to not include the default value of the `Recognizer` enum in the UI.