### PR TITLE
Rec: Implemented NotCheck and coherent Tests and helperMethods

### DIFF
--- a/PatternPal/PatternPal.Core/Checks/ICheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/ICheck.cs
@@ -312,9 +312,6 @@ internal static class CheckHelper
     /// <summary>
     /// This method checks the value of the leaf nodes and returns true if all the children are correct and false in other cases
     /// </summary>
-    /// <param name="checkResult"></param>
-    /// <returns>A bool</returns>
-    /// <exception cref="ArgumentException"></exception>
     internal static bool CheckAllChildrenCorrect(ICheckResult checkResult)
     {
         if (checkResult is LeafCheckResult leafResult)

--- a/PatternPal/PatternPal.Core/Checks/ICheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/ICheck.cs
@@ -308,6 +308,28 @@ internal static class CheckHelper
         ICheck subCheck) => new(
         parentCheck,
         subCheck );
+
+    /// <summary>
+    /// This method checks the value of the leaf nodes and returns true if all the children are correct and false in other cases
+    /// </summary>
+    /// <param name="checkResult"></param>
+    /// <returns>A bool</returns>
+    /// <exception cref="ArgumentException"></exception>
+    internal static bool CheckAllChildrenCorrect(ICheckResult checkResult)
+    {
+        if (checkResult is LeafCheckResult leafResult)
+        {
+            return leafResult.Correct;
+        }
+
+        if (checkResult is NodeCheckResult nodeResult)
+        {
+            return nodeResult.ChildrenCheckResults.All(childResult => CheckAllChildrenCorrect(childResult));
+        }
+
+        throw new ArgumentException($"Unknown ICheckResult type: {checkResult.GetType().Name}");
+
+    }
 }
 
 /// <summary>

--- a/PatternPal/PatternPal.Core/Checks/ModifierCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/ModifierCheck.cs
@@ -1,4 +1,4 @@
-﻿namespace PatternPal.Core.Checks;
+﻿ namespace PatternPal.Core.Checks;
 
 /// <summary>
 /// Checks for the modifiers of an entity. Depending on the <see cref="List{T}"/> of <see cref="IModified"/> provided.

--- a/PatternPal/PatternPal.Core/Checks/NotCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/NotCheck.cs
@@ -1,4 +1,6 @@
-﻿namespace PatternPal.Core.Checks;
+﻿using Microsoft.CodeAnalysis.Operations;
+
+namespace PatternPal.Core.Checks;
 
 internal class NotCheck : CheckBase
 {
@@ -10,12 +12,35 @@ internal class NotCheck : CheckBase
         _check = check;
     }
 
+
+    /// <summary>
+    /// This method executes all the given checks on the <paramref name="node"/>
+    /// In the subCheckResults the instances that fail the test will be stored. Thus the user should want to have an empty childrenCheckResult List.
+    /// </summary>
+    /// <param name="ctx"></param>
+    /// <param name="node"></param>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
     public override ICheckResult Check(
         RecognizerContext ctx,
         INode node)
     {
-        //Todo: add implememtation
-        // return !_check.Check( ctx, node).Correct;
-        throw new NotImplementedException("Not Check was incorrect");
+        List<ICheckResult> childResults = new List<ICheckResult>();
+
+        ICheckResult checkResult = _check.Check(ctx, node);
+
+        bool wrongImplementation = CheckHelper.CheckAllChildrenCorrect(checkResult);
+
+        if (wrongImplementation)
+        {
+            childResults.Add(checkResult);
+        }
+
+        return new NodeCheckResult
+        {
+            ChildrenCheckResults = childResults,
+            Priority = Priority,
+            FeedbackMessage = wrongImplementation ? $"Node {node} is a wrong implementation" : $"Node {node} was correctly implemented"
+        };
     }
 }

--- a/PatternPal/PatternPal.Core/Checks/NotCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/NotCheck.cs
@@ -25,8 +25,10 @@ internal class NotCheck : CheckBase
 
         ICheckResult checkResult = _check.Check(ctx, node);
 
+        // If all Leafchecks succeed, the entity which should not be present is present.
         bool wrongImplementation = CheckHelper.CheckAllChildrenCorrect(checkResult);
 
+        // In this case we add the result of the check to the childResults, because this shows which entities are present which shouldn't be.
         if (wrongImplementation)
         {
             childResults.Add(checkResult);

--- a/PatternPal/PatternPal.Core/Checks/NotCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/NotCheck.cs
@@ -17,10 +17,6 @@ internal class NotCheck : CheckBase
     /// This method executes all the given checks on the <paramref name="node"/>
     /// In the subCheckResults the instances that fail the test will be stored. Thus the user should want to have an empty childrenCheckResult List.
     /// </summary>
-    /// <param name="ctx"></param>
-    /// <param name="node"></param>
-    /// <returns></returns>
-    /// <exception cref="NotImplementedException"></exception>
     public override ICheckResult Check(
         RecognizerContext ctx,
         INode node)

--- a/PatternPal/PatternPal.Tests/Checks/CheckHelperTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/CheckHelperTests.cs
@@ -1,0 +1,46 @@
+﻿#region
+
+using static PatternPal.Core.Checks.CheckBuilder;
+
+#endregion
+
+namespace PatternPal.Tests.Checks;
+
+[TestFixture]
+public class CheckHelperTests
+{
+    [Test]
+    public void CheckAllChildrenCorrectTest()
+    {
+        // create the leaf nodes
+        ICheckResult correctLeaf = new LeafCheckResult{ Correct = true, FeedbackMessage = "", Priority = Priority.Mid };
+        ICheckResult incorrectLeaf = new LeafCheckResult { Correct = false, FeedbackMessage = "", Priority = Priority.Mid };
+        
+
+        // create the incorrect node
+        List<ICheckResult> childrenIncorrectNode = new List<ICheckResult>{ correctLeaf, incorrectLeaf };
+        ICheckResult nodeIncorrectResult = new NodeCheckResult{ChildrenCheckResults = childrenIncorrectNode, FeedbackMessage = "", Priority = Priority.Mid};
+        
+        // create the correct node
+        List<ICheckResult> childrenCorrectNode = new List<ICheckResult> { correctLeaf, correctLeaf };
+        ICheckResult nodeCorrectResult = new NodeCheckResult { ChildrenCheckResults = childrenCorrectNode, FeedbackMessage = "", Priority = Priority.Mid };
+
+        // test the correct leaf node
+        bool leafCorrect = PatternPal.Core.Checks.CheckHelper.CheckAllChildrenCorrect(correctLeaf);
+        Assert.AreEqual(true, leafCorrect);
+        
+        // test the incorrect leaf node
+        bool leafIncorrect = PatternPal.Core.Checks.CheckHelper.CheckAllChildrenCorrect(incorrectLeaf);
+        Assert.AreEqual(false, leafIncorrect);
+
+
+        // test the incorrect non-leaf node
+        bool nodeInCorrect = PatternPal.Core.Checks.CheckHelper.CheckAllChildrenCorrect(nodeIncorrectResult);
+        Assert.AreEqual(false, nodeInCorrect);
+
+        // test the correct non-leaf node
+        bool nodeCorrect = PatternPal.Core.Checks.CheckHelper.CheckAllChildrenCorrect(nodeCorrectResult);
+        Assert.AreEqual(true, nodeCorrect);
+    }
+
+}

--- a/PatternPal/PatternPal.Tests/Checks/CheckHelperTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/CheckHelperTests.cs
@@ -35,8 +35,8 @@ public class CheckHelperTests
 
 
         // test the incorrect non-leaf node
-        bool nodeInCorrect = PatternPal.Core.Checks.CheckHelper.CheckAllChildrenCorrect(nodeIncorrectResult);
-        Assert.AreEqual(false, nodeInCorrect);
+        bool nodeIncorrect = PatternPal.Core.Checks.CheckHelper.CheckAllChildrenCorrect(nodeIncorrectResult);
+        Assert.AreEqual(false, nodeIncorrect);
 
         // test the correct non-leaf node
         bool nodeCorrect = PatternPal.Core.Checks.CheckHelper.CheckAllChildrenCorrect(nodeCorrectResult);

--- a/PatternPal/PatternPal.Tests/Checks/NotCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/NotCheckTests.cs
@@ -1,0 +1,90 @@
+﻿#region
+
+using static PatternPal.Core.Checks.CheckBuilder;
+
+#endregion
+
+namespace PatternPal.Tests.Checks;
+
+internal class NotCheckTests
+{
+    [Test]
+    public void Single_Modifier_Correct_Not_Check_Test()
+    {
+        // create classEntity and RecognizerContext
+        IClass classEntity = EntityNodeUtils.CreateClass();
+        RecognizerContext ctx = new();
+
+        // create modifierCheck for private modifier
+        ModifierCheck modifierCheck2 = new ModifierCheck(Priority.Low, new List<IModifier> { Modifier.Private });
+
+        // create NotCheck for private modifier
+        NotCheck notCheck2 = Not(Priority.Low, modifierCheck2);
+
+        // create expected result for the private modifier
+        NodeCheckResult expectedResult2 = new NodeCheckResult { Priority = Priority.Low, FeedbackMessage = "", ChildrenCheckResults = new List<ICheckResult>() };
+
+        // get result of NotCheck
+        NodeCheckResult result2 = (NodeCheckResult)notCheck2.Check(ctx, classEntity);
+
+        Assert.AreEqual(expectedResult2.GetType(), result2.GetType());
+        Assert.AreEqual(expectedResult2.Priority, result2.Priority);
+        Assert.AreEqual(expectedResult2.ChildrenCheckResults.Count, result2.ChildrenCheckResults.Count);
+    }
+
+    [Test]
+    public void Single_Modifier_Incorrect_Not_Check_Test()
+    {
+        // create classEntity and RecognizerContext
+        IClass classEntity = EntityNodeUtils.CreateClass();
+        RecognizerContext ctx = new();
+
+        // create modifierCheck for the public modifier
+        ModifierCheck modifierCheck1 = new ModifierCheck(Priority.Low, new List<IModifier> { Modifier.Public });
+
+        // create NotCheck for public modifier
+        NotCheck notCheck1 = Not(Priority.Low, modifierCheck1);
+
+        // create expected result for public modifier
+        ICheckResult leafModCheckResult1 =
+            new LeafCheckResult { Priority = Priority.Low, FeedbackMessage = "", Correct = true };
+        NodeCheckResult expectedResult1 = new NodeCheckResult { Priority = Priority.Low, FeedbackMessage = "", ChildrenCheckResults = new List<ICheckResult> { leafModCheckResult1 } };
+
+        // get result of NotCheck
+        NodeCheckResult result1 = (NodeCheckResult)notCheck1.Check(ctx, classEntity);
+
+        Assert.AreEqual(expectedResult1.GetType(), result1.GetType());
+        Assert.AreEqual(expectedResult1.Priority, result1.Priority);
+        Assert.AreEqual(expectedResult1.ChildrenCheckResults.Count, result1.ChildrenCheckResults.Count);
+
+    }
+
+    [Test]
+    public void Multiple_Modifiers_Not_Check_Test()
+    {
+        // create classEntity and RecognizerContext
+        IClass classEntity = EntityNodeUtils.CreateClass();
+        RecognizerContext ctx = new();
+
+        // create modifierCheck for multiple modifiers
+        ModifierCheck modifierCheck = new ModifierCheck(Priority.Low, new List<IModifier> { Modifier.Public, Modifier.Private });
+
+        // create NotCheck for multiple modifiers
+        NotCheck notCheck = Not(Priority.Low, modifierCheck);
+
+        // create expected result for multiple modifiers
+        ICheckResult leafModCheckResult =
+            new LeafCheckResult { Priority = Priority.Low, FeedbackMessage = "", Correct = false };
+        NodeCheckResult expectedResult = new NodeCheckResult { Priority = Priority.Low, FeedbackMessage = "", ChildrenCheckResults = new List<ICheckResult> () };
+
+        // get result of NotCheck
+        NodeCheckResult result = (NodeCheckResult)notCheck.Check(ctx, classEntity);
+
+        Assert.AreEqual(expectedResult.GetType(), result.GetType());
+        Assert.AreEqual(expectedResult.Priority, result.Priority);
+        Assert.AreEqual(expectedResult.ChildrenCheckResults.Count, result.ChildrenCheckResults.Count);
+
+    }
+
+}
+


### PR DESCRIPTION
The NotCheck returns a NodeCheckResult with a list of ICheckResults as ChildrenCheckResults. This list can either be empty or store one checkResult. 
If the list is empty it means that the at least one childCheck failed and thus the NotCheck succeeded. We do not return the children in that case because it would give a lot of children. 
If the list contains an item the NotCheck failed because all the children were correct. Which lead to a case where the check in the NotCheck existed.

For questions about why I implemented it in this way feel free to contact me! 