### PR TITLE
Docs: Setup Github Pages with generated documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: Github Pages
+
+on:
+  push:
+    branches:
+      - $default-branch
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.x
+      - name: Install docfx
+        run: dotnet tool update -g docfx
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with docfx
+        run: docfx docs/docfx.json
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./docs/_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# docfx
+docs/api
+_site
+
 *.db
 
 ## Ignore Visual Studio temporary files, build results, and

--- a/PatternPal/PatternPal.Core/Checks/ClassCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/ClassCheck.cs
@@ -1,4 +1,6 @@
-﻿namespace PatternPal.Core.Checks;
+﻿using PatternPal.SyntaxTree.Abstractions.Entities;
+
+namespace PatternPal.Core.Checks;
 
 /// <summary>
 /// <see cref="ICheck"/> implementation for <see cref="IClass"/> entities.

--- a/PatternPal/PatternPal.Core/Checks/ConstructorCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/ConstructorCheck.cs
@@ -1,4 +1,7 @@
-﻿namespace PatternPal.Core.Checks;
+﻿using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+
+namespace PatternPal.Core.Checks;
 
 /// <summary>
 /// <see cref="ICheck"/> implementation for <see cref="IConstructor"/> entities.

--- a/PatternPal/PatternPal.Core/Checks/FieldCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/FieldCheck.cs
@@ -1,4 +1,6 @@
-﻿namespace PatternPal.Core.Checks;
+﻿using PatternPal.SyntaxTree.Abstractions.Members;
+
+namespace PatternPal.Core.Checks;
 
 /// <summary>
 /// <see cref="ICheck"/> implementation for <see cref="IField"/> entities.

--- a/PatternPal/PatternPal.Core/Checks/ICheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/ICheck.cs
@@ -1,4 +1,8 @@
-﻿namespace PatternPal.Core.Checks;
+﻿using PatternPal.SyntaxTree;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Models;
+
+namespace PatternPal.Core.Checks;
 
 /// <summary>
 /// Function which can be called to get an <see cref="IEntity"/>.

--- a/PatternPal/PatternPal.Core/Checks/InterfaceCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/InterfaceCheck.cs
@@ -1,4 +1,6 @@
-﻿namespace PatternPal.Core.Checks;
+﻿using PatternPal.SyntaxTree.Abstractions.Entities;
+
+namespace PatternPal.Core.Checks;
 
 /// <summary>
 /// <see cref="ICheck"/> implementation for <see cref="IInterface"/> entities.

--- a/PatternPal/PatternPal.Core/Checks/MethodCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/MethodCheck.cs
@@ -1,4 +1,7 @@
-﻿namespace PatternPal.Core.Checks;
+﻿using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+
+namespace PatternPal.Core.Checks;
 
 /// <summary>
 /// <see cref="ICheck"/> implementation for <see cref="IMethod"/> entities.

--- a/PatternPal/PatternPal.Core/Checks/ModifierCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/ModifierCheck.cs
@@ -1,4 +1,4 @@
-﻿ namespace PatternPal.Core.Checks;
+﻿  namespace PatternPal.Core.Checks;
 
 /// <summary>
 /// Checks for the modifiers of an entity. Depending on the <see cref="List{T}"/> of <see cref="IModified"/> provided.

--- a/PatternPal/PatternPal.Core/Checks/NodeCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/NodeCheck.cs
@@ -1,4 +1,6 @@
-﻿namespace PatternPal.Core.Checks;
+﻿using PatternPal.SyntaxTree.Abstractions.Entities;
+
+namespace PatternPal.Core.Checks;
 
 /// <summary>
 /// Base class for <see cref="ICheck"/>s which can have sub-<see cref="ICheck"/>s.

--- a/PatternPal/PatternPal.Core/Checks/ParameterCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/ParameterCheck.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
+using PatternPal.SyntaxTree.Abstractions.Entities;
+
 namespace PatternPal.Core.Checks;
 
 /// <summary>

--- a/PatternPal/PatternPal.Core/Checks/PropertyCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/PropertyCheck.cs
@@ -1,4 +1,6 @@
-﻿namespace PatternPal.Core.Checks;
+﻿using PatternPal.SyntaxTree.Abstractions.Members;
+
+namespace PatternPal.Core.Checks;
 
 /// <summary>
 /// <see cref="ICheck"/> implementation for <see cref="IProperty"/> entities.

--- a/PatternPal/PatternPal.Core/GlobalUsings.cs
+++ b/PatternPal/PatternPal.Core/GlobalUsings.cs
@@ -8,12 +8,7 @@ global using System.Linq;
 global using OneOf;
 
 global using PatternPal.Core.Checks;
-
-global using SyntaxTree;
-global using SyntaxTree.Abstractions;
-global using SyntaxTree.Abstractions.Entities;
-global using SyntaxTree.Abstractions.Members;
-global using SyntaxTree.Models;
+global using PatternPal.SyntaxTree.Abstractions;
 
 using System.Runtime.CompilerServices;
 

--- a/PatternPal/PatternPal.Core/Models/RecognitionResult.cs
+++ b/PatternPal/PatternPal.Core/Models/RecognitionResult.cs
@@ -1,4 +1,5 @@
 using PatternPal.Recognizers.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
 
 namespace PatternPal.Core.Models
 {

--- a/PatternPal/PatternPal.Core/RecognizerContext.cs
+++ b/PatternPal/PatternPal.Core/RecognizerContext.cs
@@ -1,4 +1,7 @@
-﻿namespace PatternPal.Core;
+﻿using PatternPal.SyntaxTree;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+
+namespace PatternPal.Core;
 
 // TODO CV: Make immutable to force a reset of the properties on each check level.
 internal class RecognizerContext

--- a/PatternPal/PatternPal.Core/RecognizerRunner.cs
+++ b/PatternPal/PatternPal.Core/RecognizerRunner.cs
@@ -3,6 +3,8 @@
 using PatternPal.Core.Models;
 using PatternPal.Core.Recognizers;
 using PatternPal.Protos;
+using PatternPal.SyntaxTree;
+using PatternPal.SyntaxTree.Abstractions.Entities;
 
 #endregion
 

--- a/PatternPal/PatternPal.Core/Recognizers/SingletonRecognizer.cs
+++ b/PatternPal/PatternPal.Core/Recognizers/SingletonRecognizer.cs
@@ -1,5 +1,7 @@
 ﻿#region
 
+using PatternPal.SyntaxTree.Models;
+
 using static PatternPal.Core.Checks.CheckBuilder;
 
 #endregion

--- a/PatternPal/PatternPal.Regonizers/Abstractions/ICheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Abstractions/ICheck.cs
@@ -1,4 +1,4 @@
-﻿using SyntaxTree.Abstractions;
+﻿using PatternPal.SyntaxTree.Abstractions;
 
 namespace PatternPal.Recognizers.Abstractions
 {

--- a/PatternPal/PatternPal.Regonizers/Abstractions/ICheckResult.cs
+++ b/PatternPal/PatternPal.Regonizers/Abstractions/ICheckResult.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
-using SyntaxTree.Abstractions;
+
+using PatternPal.SyntaxTree.Abstractions;
 
 namespace PatternPal.Recognizers.Abstractions
 {

--- a/PatternPal/PatternPal.Regonizers/Abstractions/IResult.cs
+++ b/PatternPal/PatternPal.Regonizers/Abstractions/IResult.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
-using SyntaxTree.Abstractions.Entities;
+
+using PatternPal.SyntaxTree.Abstractions.Entities;
 
 namespace PatternPal.Recognizers.Abstractions
 {

--- a/PatternPal/PatternPal.Regonizers/Checks/FieldChecks.cs
+++ b/PatternPal/PatternPal.Regonizers/Checks/FieldChecks.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions.Members;
+
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Checks
 {

--- a/PatternPal/PatternPal.Regonizers/Checks/MethodChecks.cs
+++ b/PatternPal/PatternPal.Regonizers/Checks/MethodChecks.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-using SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Checks
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/AbstractListCheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/AbstractListCheck.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using PatternPal.Recognizers.Abstractions;
 using PatternPal.Recognizers.Models.ElementChecks;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions;
 
 namespace PatternPal.Recognizers.Models.Checks
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/EntityCheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/EntityCheck.cs
@@ -4,9 +4,9 @@ using PatternPal.Recognizers.Abstractions;
 using PatternPal.Recognizers.Models.Checks.Entities.GroupChecks;
 using PatternPal.Recognizers.Models.Checks.Members;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Entities;
-using SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Entities
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/GroupChecks/AllMemberGroupCheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/GroupChecks/AllMemberGroupCheck.cs
@@ -2,8 +2,8 @@
 using System.Linq;
 using PatternPal.Recognizers.Abstractions;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions.Entities;
-using SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Entities.GroupChecks
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/GroupChecks/AnyMemberGroupCheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/GroupChecks/AnyMemberGroupCheck.cs
@@ -2,8 +2,8 @@
 using System.Linq;
 using PatternPal.Recognizers.Abstractions;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions.Entities;
-using SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Entities.GroupChecks
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/GroupChecks/MemberGroupCheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/GroupChecks/MemberGroupCheck.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using PatternPal.Recognizers.Abstractions;
 using PatternPal.Recognizers.Models.Checks.Entities.MemberBuilders;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions.Entities;
-using SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Entities.GroupChecks
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/MemberBuilders/ConstructorCheckBuilder.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/MemberBuilders/ConstructorCheckBuilder.cs
@@ -1,7 +1,7 @@
 ﻿using PatternPal.Recognizers.Models.Checks.Members;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions.Entities;
-using SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Entities.MemberBuilders
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/MemberBuilders/FieldCheckBuilder.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/MemberBuilders/FieldCheckBuilder.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using PatternPal.Recognizers.Models.Checks.Members;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions.Entities;
-using SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Entities.MemberBuilders
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/MemberBuilders/MethodCheckBuilder.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/MemberBuilders/MethodCheckBuilder.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using PatternPal.Recognizers.Models.Checks.Members;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions.Entities;
-using SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Entities.MemberBuilders
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/MemberCheckBuilder.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Entities/MemberCheckBuilder.cs
@@ -5,9 +5,9 @@ using PatternPal.Recognizers.Abstractions;
 using PatternPal.Recognizers.Models.Checks.Entities.GroupChecks;
 using PatternPal.Recognizers.Models.Checks.Members;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Entities;
-using SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Entities
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Members/AbstractMemberListCheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Members/AbstractMemberListCheck.cs
@@ -1,6 +1,5 @@
 ﻿using PatternPal.Recognizers.Models.Output;
-
-using SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Members
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Members/ConstructorCheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Members/ConstructorCheck.cs
@@ -1,4 +1,4 @@
-﻿using SyntaxTree.Abstractions.Members;
+﻿using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Members
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Members/FieldCheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Members/FieldCheck.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using PatternPal.Recognizers.Checks;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions.Entities;
-using SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Members
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/Members/MethodCheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/Members/MethodCheck.cs
@@ -1,4 +1,4 @@
-﻿using SyntaxTree.Abstractions.Members;
+﻿using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers.Models.Checks.Members
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Checks/ModifierCheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Checks/ModifierCheck.cs
@@ -2,7 +2,8 @@
 using System.Linq;
 using PatternPal.Recognizers.Abstractions;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions;
+
 using static PatternPal.Recognizers.Abstractions.FeedbackType;
 
 namespace PatternPal.Recognizers.Models.Checks

--- a/PatternPal/PatternPal.Regonizers/Models/ElementChecks/ElementCheck.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/ElementChecks/ElementCheck.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using PatternPal.Recognizers.Abstractions;
 using PatternPal.Recognizers.Models.Output;
-using SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions;
 
 namespace PatternPal.Recognizers.Models.ElementChecks
 {

--- a/PatternPal/PatternPal.Regonizers/Models/Output/CheckResult.cs
+++ b/PatternPal/PatternPal.Regonizers/Models/Output/CheckResult.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using PatternPal.Recognizers.Abstractions;
-using SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions;
 
 namespace PatternPal.Recognizers.Models.Output
 {

--- a/PatternPal/PatternPal.Regonizers/TempUtils.cs
+++ b/PatternPal/PatternPal.Regonizers/TempUtils.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using SyntaxTree.Abstractions.Entities;
-using SyntaxTree.Abstractions.Members;
+
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
 
 namespace PatternPal.Recognizers
 {

--- a/PatternPal/PatternPal.StepByStep/Abstractions/IInstructionState.cs
+++ b/PatternPal/PatternPal.StepByStep/Abstractions/IInstructionState.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 
-using SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Entities;
 
 #endregion
 

--- a/PatternPal/PatternPal.StepByStep/InstructionSets/StrategyInstructionSet.cs
+++ b/PatternPal/PatternPal.StepByStep/InstructionSets/StrategyInstructionSet.cs
@@ -13,9 +13,11 @@ using PatternPal.StepByStep.Models;
 using PatternPal.StepByStep.Resources.Instructions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Entities;
-using SyntaxTree.Models;
+
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Models;
+
 using static PatternPal.Core.Resources.DesignPatternNameResources;
 
 namespace PatternPal.StepByStep.InstructionSets

--- a/PatternPal/PatternPal.StepByStep/InstructionState.cs
+++ b/PatternPal/PatternPal.StepByStep/InstructionState.cs
@@ -3,8 +3,7 @@
 using System.Collections.Generic;
 
 using PatternPal.StepByStep.Abstractions;
-
-using SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Entities;
 
 #endregion
 

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/Entities/IClass.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/Entities/IClass.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 
-namespace SyntaxTree.Abstractions.Entities
+using PatternPal.SyntaxTree.Abstractions.Members;
+
+namespace PatternPal.SyntaxTree.Abstractions.Entities
 {
     public interface IClass : IEntity
     {

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/Entities/IEntity.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/Entities/IEntity.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-using SyntaxTree.Abstractions.Root;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Root;
 
-namespace SyntaxTree.Abstractions.Entities
+namespace PatternPal.SyntaxTree.Abstractions.Entities
 {
     public interface IEntity : IModified, IChild<IEntitiesContainer>, INamedEntitiesContainer
     {

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/Entities/IInterface.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/Entities/IInterface.cs
@@ -1,4 +1,4 @@
-﻿namespace SyntaxTree.Abstractions.Entities
+﻿namespace PatternPal.SyntaxTree.Abstractions.Entities
 {
     public interface IInterface : IEntity
     {

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/IModifier.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/IModifier.cs
@@ -1,4 +1,4 @@
-﻿namespace SyntaxTree.Abstractions
+﻿namespace PatternPal.SyntaxTree.Abstractions
 {
     public interface IModifier
     {

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/INode.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/INode.cs
@@ -1,11 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions.Root;
 
-namespace SyntaxTree.Abstractions
+using PatternPal.SyntaxTree.Abstractions.Root;
+
+namespace PatternPal.SyntaxTree.Abstractions
 {
     public interface INode
     {

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/Members/IConstructor.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/Members/IConstructor.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Generic;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace SyntaxTree.Abstractions.Members
+using PatternPal.SyntaxTree.Abstractions.Entities;
+
+namespace PatternPal.SyntaxTree.Abstractions.Members
 {
     public interface IConstructor : IMember, IParameterized, IBodied, IChild<IClass>
     {

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/Members/IField.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/Members/IField.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace SyntaxTree.Abstractions.Members
+namespace PatternPal.SyntaxTree.Abstractions.Members
 {
     public interface IField : IMember
     {

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/Members/IMember.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/Members/IMember.cs
@@ -1,4 +1,6 @@
-﻿namespace SyntaxTree.Abstractions.Members
+﻿using PatternPal.SyntaxTree.Abstractions.Entities;
+
+namespace PatternPal.SyntaxTree.Abstractions.Members
 {
     public interface IMember : IModified, IChild<IEntity>
     {

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/Members/IMethod.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/Members/IMethod.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace SyntaxTree.Abstractions.Members
+namespace PatternPal.SyntaxTree.Abstractions.Members
 {
     public interface IMethod : IMember, IParameterized, IBodied
     {

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/Members/IProperty.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/Members/IProperty.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace SyntaxTree.Abstractions.Members
+namespace PatternPal.SyntaxTree.Abstractions.Members
 {
     public interface IProperty : IMember
     {

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/Relation.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/Relation.cs
@@ -1,4 +1,7 @@
-﻿namespace SyntaxTree.Abstractions;
+﻿using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+
+namespace PatternPal.SyntaxTree.Abstractions;
 
 public class Relation
 {

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/Root/INamespace.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/Root/INamespace.cs
@@ -1,4 +1,4 @@
-﻿namespace SyntaxTree.Abstractions.Root
+﻿namespace PatternPal.SyntaxTree.Abstractions.Root
 {
     public interface INamespace
         : INamespaceContainer, IUsingContainer, INamedEntitiesContainer, IChild<INamespaceContainer>

--- a/PatternPal/PatternPal.SyntaxTree/Abstractions/Root/IRoot.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Abstractions/Root/IRoot.cs
@@ -1,7 +1,10 @@
 ﻿using System.Collections.Generic;
+
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace SyntaxTree.Abstractions.Root
+using PatternPal.SyntaxTree.Abstractions.Entities;
+
+namespace PatternPal.SyntaxTree.Abstractions.Root
 {
     public interface IRoot : IEntitiesContainer, INamespaceContainer, IUsingContainer
     {

--- a/PatternPal/PatternPal.SyntaxTree/GlobalUsings.cs
+++ b/PatternPal/PatternPal.SyntaxTree/GlobalUsings.cs
@@ -4,9 +4,6 @@ global using Microsoft.CodeAnalysis;
 
 global using OneOf;
 
-global using SyntaxTree.Abstractions.Entities;
-global using SyntaxTree.Abstractions.Members;
-
 using System.Runtime.CompilerServices;
 
 //[assembly: InternalsVisibleTo("PatternPal.Tests")]

--- a/PatternPal/PatternPal.SyntaxTree/Models/AbstractNode.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/AbstractNode.cs
@@ -1,7 +1,7 @@
-﻿using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Root;
+﻿using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Root;
 
-namespace SyntaxTree.Models
+namespace PatternPal.SyntaxTree.Models
 {
     public abstract class AbstractNode : INode
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Entities/AbstractEntity.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Entities/AbstractEntity.cs
@@ -1,15 +1,18 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Root;
-using SyntaxTree.Models.Members.Constructor;
-using SyntaxTree.Models.Members.Method;
-using SyntaxTree.Models.Members.Property;
-using SyntaxTree.Utils;
 
-namespace SyntaxTree.Models.Entities
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Root;
+using PatternPal.SyntaxTree.Models.Members.Constructor;
+using PatternPal.SyntaxTree.Models.Members.Method;
+using PatternPal.SyntaxTree.Models.Members.Property;
+using PatternPal.SyntaxTree.Utils;
+
+namespace PatternPal.SyntaxTree.Models.Entities
 {
     public abstract class AbstractEntity : AbstractNode, IEntity
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Entities/Class.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Entities/Class.cs
@@ -1,12 +1,16 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Root;
-using SyntaxTree.Models.Members.Constructor;
-using SyntaxTree.Models.Members.Field;
 
-namespace SyntaxTree.Models.Entities
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Root;
+using PatternPal.SyntaxTree.Models.Members.Constructor;
+using PatternPal.SyntaxTree.Models.Members.Field;
+
+namespace PatternPal.SyntaxTree.Models.Entities
 {
     public class Class : AbstractEntity, IClass
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Entities/Interface.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Entities/Interface.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-using SyntaxTree.Abstractions.Root;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Root;
 
-namespace SyntaxTree.Models.Entities
+namespace PatternPal.SyntaxTree.Models.Entities
 {
     public class Interface : AbstractEntity, IInterface
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Members/Constructor/Constructor.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Members/Constructor/Constructor.cs
@@ -1,11 +1,15 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Utils;
 
-namespace SyntaxTree.Models.Members.Constructor
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Utils;
+
+namespace PatternPal.SyntaxTree.Models.Members.Constructor
 {
     public class Constructor : AbstractNode, IConstructor
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Members/Constructor/ConstructorMethod.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Members/Constructor/ConstructorMethod.cs
@@ -1,10 +1,14 @@
 ﻿using System.Collections.Generic;
+
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Root;
 
-namespace SyntaxTree.Models.Members.Constructor
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Root;
+
+namespace PatternPal.SyntaxTree.Models.Members.Constructor
 {
     public class ConstructorMethod : IMethod
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Members/Field/Field.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Members/Field/Field.cs
@@ -1,10 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Utils;
 
-namespace SyntaxTree.Models.Members.Field
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Utils;
+
+namespace PatternPal.SyntaxTree.Models.Members.Field
 {
     public class Field : AbstractNode, IField
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Members/Method/Method.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Members/Method/Method.cs
@@ -1,10 +1,14 @@
 ﻿using System.Collections.Generic;
+
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Utils;
 
-namespace SyntaxTree.Models.Members.Method
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Utils;
+
+namespace PatternPal.SyntaxTree.Models.Members.Method
 {
     public class Method : AbstractNode, IMethod
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Members/Property/Property.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Members/Property/Property.cs
@@ -1,11 +1,15 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Utils;
 
-namespace SyntaxTree.Models.Members.Property
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Utils;
+
+namespace PatternPal.SyntaxTree.Models.Members.Property
 {
     public class Property : AbstractNode, IProperty
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Members/Property/PropertyField.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Members/Property/PropertyField.cs
@@ -1,9 +1,13 @@
 ﻿using System.Collections.Generic;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Root;
 
-namespace SyntaxTree.Models.Members.Property
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Root;
+
+namespace PatternPal.SyntaxTree.Models.Members.Property
 {
     public class PropertyField : IField
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Members/Property/PropertyMethod.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Members/Property/PropertyMethod.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Root;
 
-namespace SyntaxTree.Models.Members.Property
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Root;
+
+namespace PatternPal.SyntaxTree.Models.Members.Property
 {
     public abstract class PropertyMethod : IMethod
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Modifiers.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Modifiers.cs
@@ -1,6 +1,6 @@
-﻿using SyntaxTree.Abstractions;
+﻿using PatternPal.SyntaxTree.Abstractions;
 
-namespace SyntaxTree.Models
+namespace PatternPal.SyntaxTree.Models
 {
     public class Modifier : IModifier
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Root/Namespace.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Root/Namespace.cs
@@ -1,11 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Root;
-using SyntaxTree.Utils;
 
-namespace SyntaxTree.Models.Root
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Root;
+using PatternPal.SyntaxTree.Utils;
+
+namespace PatternPal.SyntaxTree.Models.Root
 {
     public class Namespace : AbstractNode, INamespace
     {

--- a/PatternPal/PatternPal.SyntaxTree/Models/Root/Root.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Models/Root/Root.cs
@@ -1,11 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Root;
-using SyntaxTree.Utils;
 
-namespace SyntaxTree.Models.Root
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Root;
+using PatternPal.SyntaxTree.Utils;
+
+namespace PatternPal.SyntaxTree.Models.Root
 {
     public class Root : AbstractNode, IRoot
     {

--- a/PatternPal/PatternPal.SyntaxTree/PatternPal.SyntaxTree.csproj
+++ b/PatternPal/PatternPal.SyntaxTree/PatternPal.SyntaxTree.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <RootNamespace>SyntaxTree</RootNamespace>
+    <RootNamespace>PatternPal.SyntaxTree</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PatternPal/PatternPal.SyntaxTree/Relations.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Relations.cs
@@ -6,12 +6,14 @@ using System.Linq;
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-using SyntaxTree.Abstractions;
-using SyntaxTree.Models.Members.Method;
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Models.Members.Method;
 
 #endregion
 
-namespace SyntaxTree
+namespace PatternPal.SyntaxTree
 {
     public class Relations
     {

--- a/PatternPal/PatternPal.SyntaxTree/SemanticModels.cs
+++ b/PatternPal/PatternPal.SyntaxTree/SemanticModels.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
+
 using Microsoft.CodeAnalysis.CSharp;
 
-namespace SyntaxTree
+namespace PatternPal.SyntaxTree
 {
     public static class SemanticModels
     {

--- a/PatternPal/PatternPal.SyntaxTree/SyntaxGraph.cs
+++ b/PatternPal/PatternPal.SyntaxTree/SyntaxGraph.cs
@@ -5,13 +5,15 @@ using System.Linq;
 
 using Microsoft.CodeAnalysis.CSharp;
 
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Root;
-using SyntaxTree.Models.Root;
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Root;
+using PatternPal.SyntaxTree.Models.Root;
 
 #endregion
 
-namespace SyntaxTree
+namespace PatternPal.SyntaxTree
 {
     public class SyntaxGraph
     {

--- a/PatternPal/PatternPal.SyntaxTree/Utils/SyntaxUtils.cs
+++ b/PatternPal/PatternPal.SyntaxTree/Utils/SyntaxUtils.cs
@@ -1,13 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SyntaxTree.Abstractions;
-using SyntaxTree.Abstractions.Root;
-using SyntaxTree.Models;
-using SyntaxTree.Models.Entities;
 
-namespace SyntaxTree.Utils
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Root;
+using PatternPal.SyntaxTree.Models;
+using PatternPal.SyntaxTree.Models.Entities;
+
+namespace PatternPal.SyntaxTree.Utils
 {
     public static class SyntaxUtils
     {

--- a/PatternPal/PatternPal.Tests/Checks/CheckCollectionTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/CheckCollectionTests.cs
@@ -1,5 +1,7 @@
 ﻿#region
 
+using PatternPal.SyntaxTree.Abstractions.Entities;
+
 using static PatternPal.Core.Checks.CheckBuilder;
 
 #endregion

--- a/PatternPal/PatternPal.Tests/Checks/ClassCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/ClassCheckTests.cs
@@ -1,5 +1,9 @@
 ﻿#region
 
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Models;
+
 using static PatternPal.Core.Checks.CheckBuilder;
 
 #endregion

--- a/PatternPal/PatternPal.Tests/Checks/ConstructorCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/ConstructorCheckTests.cs
@@ -1,5 +1,8 @@
 ﻿#region
 
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Models;
+
 using static PatternPal.Core.Checks.CheckBuilder;
 
 #endregion

--- a/PatternPal/PatternPal.Tests/Checks/FieldCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/FieldCheckTests.cs
@@ -1,5 +1,9 @@
 ﻿#region
 
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Models;
+
 using static PatternPal.Core.Checks.CheckBuilder;
 
 #endregion

--- a/PatternPal/PatternPal.Tests/Checks/InterfaceCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/InterfaceCheckTests.cs
@@ -1,5 +1,9 @@
 ﻿#region
 
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Models;
+
 using static PatternPal.Core.Checks.CheckBuilder;
 
 #endregion

--- a/PatternPal/PatternPal.Tests/Checks/MethodCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/MethodCheckTests.cs
@@ -1,5 +1,9 @@
 ﻿#region
 
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Models;
+
 using static PatternPal.Core.Checks.CheckBuilder;
 
 #endregion

--- a/PatternPal/PatternPal.Tests/Checks/ModifierCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/ModifierCheckTests.cs
@@ -1,6 +1,8 @@
 ﻿#region
 
-using SyntaxTree.Abstractions.Root;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Root;
+using PatternPal.SyntaxTree.Models;
 
 using static PatternPal.Core.Checks.CheckBuilder;
 

--- a/PatternPal/PatternPal.Tests/Checks/NotCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/NotCheckTests.cs
@@ -1,5 +1,8 @@
 ﻿#region
 
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Models;
+
 using static PatternPal.Core.Checks.CheckBuilder;
 
 #endregion

--- a/PatternPal/PatternPal.Tests/Checks/ParameterCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/ParameterCheckTests.cs
@@ -1,4 +1,9 @@
 ﻿#region
+
+using PatternPal.SyntaxTree;
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Members;
+
 using static PatternPal.Core.Checks.CheckBuilder;
 #endregion
 

--- a/PatternPal/PatternPal.Tests/Checks/PropertyCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/PropertyCheckTests.cs
@@ -1,5 +1,8 @@
 ﻿#region
 
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Models;
+
 using static PatternPal.Core.Checks.CheckBuilder;
 
 #endregion

--- a/PatternPal/PatternPal.Tests/Checks/RelationCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/RelationCheckTests.cs
@@ -1,5 +1,8 @@
 ﻿#region
 
+using PatternPal.SyntaxTree;
+using PatternPal.SyntaxTree.Abstractions;
+
 using static PatternPal.Core.Checks.CheckBuilder;
 
 #endregion

--- a/PatternPal/PatternPal.Tests/Checks/TypeCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/TypeCheckTests.cs
@@ -1,4 +1,8 @@
-﻿namespace PatternPal.Tests.Checks;
+﻿using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+
+namespace PatternPal.Tests.Checks;
 
 [TestFixture]
 public class TypeCheckTests

--- a/PatternPal/PatternPal.Tests/Core/GenerateSyntaxTreeTest.cs
+++ b/PatternPal/PatternPal.Tests/Core/GenerateSyntaxTreeTest.cs
@@ -1,6 +1,9 @@
 using Microsoft.CodeAnalysis;
 using NUnit.Framework;
 
+using PatternPal.SyntaxTree;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+
 namespace PatternPal.Tests.Core
 {
     internal class GenerateSyntaxTreeTest

--- a/PatternPal/PatternPal.Tests/Core/RelationTest.cs
+++ b/PatternPal/PatternPal.Tests/Core/RelationTest.cs
@@ -1,6 +1,8 @@
 ﻿using NUnit.Framework;
 
-using SyntaxTree.Models.Members.Method;
+using PatternPal.SyntaxTree;
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Models.Members.Method;
 
 namespace PatternPal.Tests.Core
 {

--- a/PatternPal/PatternPal.Tests/GlobalUsings.cs
+++ b/PatternPal/PatternPal.Tests/GlobalUsings.cs
@@ -17,11 +17,4 @@ global using PatternPal.Core;
 global using PatternPal.Core.Checks;
 global using PatternPal.Tests.Utils;
 
-global using SyntaxTree;
-global using SyntaxTree.Abstractions;
-global using SyntaxTree.Abstractions.Entities;
-global using SyntaxTree.Abstractions.Members;
-global using SyntaxTree.Models;
-global using SyntaxTree.Models.Entities;
-
 global using VerifyNUnit;

--- a/PatternPal/PatternPal.Tests/StepByStep/TestInstructionState.cs
+++ b/PatternPal/PatternPal.Tests/StepByStep/TestInstructionState.cs
@@ -1,4 +1,6 @@
 ﻿using PatternPal.StepByStep.Abstractions;
+using PatternPal.SyntaxTree;
+using PatternPal.SyntaxTree.Abstractions.Entities;
 
 namespace PatternPal.Tests.StepByStep
 {

--- a/PatternPal/PatternPal.Tests/Utils/EntityNodeUtils.cs
+++ b/PatternPal/PatternPal.Tests/Utils/EntityNodeUtils.cs
@@ -2,13 +2,18 @@
 
 using Microsoft.CodeAnalysis;
 
-using SyntaxTree.Abstractions.Root;
-using SyntaxTree.Models.Members.Constructor;
-using SyntaxTree.Models.Members.Field;
-using SyntaxTree.Models.Members.Method;
-using SyntaxTree.Models.Members.Property;
-using SyntaxTree.Models.Root;
-using SyntaxTree.Utils;
+using PatternPal.SyntaxTree;
+using PatternPal.SyntaxTree.Abstractions;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+using PatternPal.SyntaxTree.Abstractions.Members;
+using PatternPal.SyntaxTree.Abstractions.Root;
+using PatternPal.SyntaxTree.Models.Entities;
+using PatternPal.SyntaxTree.Models.Members.Constructor;
+using PatternPal.SyntaxTree.Models.Members.Field;
+using PatternPal.SyntaxTree.Models.Members.Method;
+using PatternPal.SyntaxTree.Models.Members.Property;
+using PatternPal.SyntaxTree.Models.Root;
+using PatternPal.SyntaxTree.Utils;
 
 #endregion
 

--- a/PatternPal/PatternPal/GlobalUsings.cs
+++ b/PatternPal/PatternPal/GlobalUsings.cs
@@ -10,8 +10,5 @@ global using PatternPal.Recognizers.Abstractions;
 global using PatternPal.StepByStep;
 global using PatternPal.StepByStep.Abstractions;
 
-global using SyntaxTree;
-global using SyntaxTree.Abstractions.Entities;
-
 global using RecognizerService = PatternPal.Services.RecognizerService;
 global using StepByStepService = PatternPal.Services.StepByStepService;

--- a/PatternPal/PatternPal/Services/StepByStepService.cs
+++ b/PatternPal/PatternPal/Services/StepByStepService.cs
@@ -1,4 +1,7 @@
-﻿namespace PatternPal.Services;
+﻿using PatternPal.SyntaxTree;
+using PatternPal.SyntaxTree.Abstractions.Entities;
+
+namespace PatternPal.Services;
 
 public class StepByStepService : Protos.StepByStepService.StepByStepServiceBase
 {

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -1,0 +1,51 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "src": "../",
+          "files": [
+            "PatternPal/PatternPal/PatternPal.csproj",
+            "PatternPal/PatternPal.CommonResources/PatternPal.CommonResources.csproj",
+            "PatternPal/PatternPal.Console/PatternPal.ConsoleApp.csproj",
+            "PatternPal/PatternPal.Core/PatternPal.Core.csproj",
+            "PatternPal/PatternPal.LoggingServer/PatternPal.LoggingServer.csproj",
+            "PatternPal/PatternPal.Regonizers/PatternPal.Recognizers.csproj",
+            "PatternPal/PatternPal.StepByStep/PatternPal.StepByStep.csproj",
+            "PatternPal/PatternPal.SyntaxTree/PatternPal.SyntaxTree.csproj",
+            "PatternPal/PatternPal.TestRunner/PatternPal.TestRunner.csproj"
+          ]
+        }
+      ],
+      "dest": "api",
+      "includePrivateMembers": true,
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false,
+      "noRestore": false,
+      "namespaceLayout": "nested",
+      "memberLayout": "samePage",
+      "allowCompilationErrors": false
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": ["**/*.{md,yml}"],
+        "exclude": ["_site/**", "obj/**"]
+      }
+    ],
+    "resource": [
+      {
+        "files": ["**/images/**"],
+        "exclude": ["_site/**", "obj/**"]
+      }
+    ],
+    "output": "_site",
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "template": ["default", "modern"],
+    "postProcessors": [],
+    "keepFileLink": false,
+    "disableGitFeatures": false
+  }
+}

--- a/docs/docs/how-to/implement_extension.md
+++ b/docs/docs/how-to/implement_extension.md
@@ -1,0 +1,1 @@
+# Implement an Extension

--- a/docs/docs/how-to/implement_recognizer.md
+++ b/docs/docs/how-to/implement_recognizer.md
@@ -1,0 +1,1 @@
+# Implement a Recognizer

--- a/docs/docs/recognizers/singleton.md
+++ b/docs/docs/recognizers/singleton.md
@@ -1,0 +1,1 @@
+# Singleton

--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -1,0 +1,13 @@
+- name: Get started
+- name: Home
+  href: ../index.md
+
+- name: Recognizers
+- name: Singleton
+  href: recognizers/singleton.md
+
+- name: How to
+- name: Implement a Recognizer
+  href: how-to/implement_recognizer.md
+- name: Implement an Extension
+  href: how-to/implement_extension.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,56 @@
+# PatternPal
+
+A Visual Studio extension that detects design patterns and helps users implement them.
+Documentation (as of 03/2023: outdated) on the [Wiki](https://github.com/PatternPal/PatternPal/wiki).
+
+## Requirements
+
+- Visual Studio 2022
+
+## Installation
+
+You can download the extension installer from the [releases page]. Unzip the `PatternPal` folder and
+run the included `PatternPal.Extension.vsix` installer. This will open a prompt to install
+PatternPal into your Visual Studio 2022 instance. After the installation has succeeded, you can
+access PatternPal from `View > Other Windows > PatternPal Extension`.
+
+## Usage
+
+### Opening extension
+
+You can open the main view of the extension through `View > Other Windows > PatternPal Extension`.
+
+## Authors
+
+Project coordinator: [Hieke Keuning](https://github.com/hiekekeuning) (h.w.keuning@uu.nl), Utrecht University
+
+### Team 2023 (Utrecht University)
+
+- [Matteo Bertorotta](https://github.com/viciousdoormat)
+- [Daan van Dam](https://github.com/danielvandamme)
+- [Wing Toh Wong](https://github.com/wingtoh)
+- [Casper Verhaar](https://github.com/knapsac)
+- [Siem van den Tweel](https://github.com/justnireon)
+- [Rutger Vincken](https://github.com/rutgervincken)
+- [Linde van Werven](https://github.com/lvanwerven)
+- [Jeroen van Dam](https://github.com/captainjeroen)
+- [Olaf van der Aart](https://github.com/ovda96)
+
+### Team 2021-2022 (Windesheim University of Applied Sciences)
+
+- [Frank Stam](https://github.com/FrankS01)
+- Jasper van Veenhuizen
+- [Nienke Hulzebos](https://github.com/nienkehulzebos)
+- [Sven Boogaard](https://github.com/sven2102)
+- [Zeewar Ghafir](https://github.com/zeewar)
+- [Koen van Staveren](https://github.com/UnderKoen)
+
+### Team 2019-2020 (Windesheim University of Applied Sciences)
+
+- Henrico Pops
+- Jacq Wattel
+- Tristan Heizenberg
+- Nick Chen
+- Shanna van Grevengoed
+
+[releases page]: https://github.com/PatternPal/PatternPal/releases/latest

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,4 @@
+- name: Docs
+  href: docs/
+- name: API
+  href: api/


### PR DESCRIPTION
Use [docfx](https://dotnet.github.io/docfx/) to generate documentation from static files in the `docs/` directory as well as from code comments.

Also change the default namespace of the `SyntaxTree` project so it matches with the rest of the projects. This makes the generated documentation nicer, as all namespaces share the same root. 