### PR TITLE
Ci: Fix branch name in publish docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Github Pages
 on:
   push:
     branches:
-      - $default-branch
+      - develop
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
Apparently `$default_branch` only works in workflow templates, not in workflowes themselves.