### PR TITLE
CI: Skip steps individually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       should_run:
         required: true
-        type: true
+        type: boolean
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,16 @@ name: Build
 
 on:
   workflow_call:
+    inputs:
+      should_run:
+        required: true
+        type: true
   workflow_dispatch:
 
 jobs:
   Build_Logserver:
     runs-on: ubuntu-latest
+    if: inputs.should_run
     steps:
       - uses: actions/checkout@v3
       - name: Set up docker BuildX
@@ -19,6 +24,7 @@ jobs:
 
   Build:
     runs-on: windows-latest
+    if: inputs.should_run
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       should_run:
         required: true
-        type: true
+        type: boolean
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,16 @@ name: Lint
 
 on:
   workflow_call:
+    inputs:
+      should_run:
+        required: true
+        type: true
   workflow_dispatch:
 
 jobs:
   inspection:
     runs-on: windows-latest
+    if: inputs.should_run
     name: Inspection
     steps:
       - name: Checkout

--- a/.github/workflows/patternpal.yml
+++ b/.github/workflows/patternpal.yml
@@ -33,16 +33,19 @@ jobs:
         run: echo PatternPal has changed files
 
   build:
-    if: github.event.pull_request.draft == false && needs.should_run.outputs.status == 'success'
     needs: should_run
     uses: ./.github/workflows/build.yml
+    with:
+      should_run: ${{ needs.should_run.outputs.status == 'success' }}
 
   test:
-    if: github.event.pull_request.draft == false && needs.should_run.outputs.status == 'success'
     needs: should_run
     uses: ./.github/workflows/test.yml
+    with:
+      should_run: ${{ needs.should_run.outputs.status == 'success' }}
 
   lint:
-    if: github.event.pull_request.draft == false && needs.should_run.outputs.status == 'success'
     needs: should_run
     uses: ./.github/workflows/lint.yml
+    with:
+      should_run: ${{ needs.should_run.outputs.status == 'success' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       should_run:
         required: true
-        type: true
+        type: boolean
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,16 @@ name: Test
 
 on:
   workflow_call:
+    inputs:
+      should_run:
+        required: true
+        type: true
   workflow_dispatch:
 
 jobs:
   Test:
     runs-on: windows-latest
+    if: inputs.should_run
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
When skipping the entire sub-workflows, the skipped name differs from when the workflow is run. This makes it impossible to define the checks which are required for merging, because you can't specify both, as they never apply at the same time. To circumvent this issue, I moved the skipping of steps to the sub-workflows, which means the check names are always the same, regardless of whether they're skipped or run.