### PR TITLE
Log: Hotfix for logs Project.Open and Project.Close

### DIFF
--- a/PatternPal/PatternPal.Extension/PatternPal.ExtensionPackage.cs
+++ b/PatternPal/PatternPal.Extension/PatternPal.ExtensionPackage.cs
@@ -144,13 +144,16 @@ namespace PatternPal.Extension
 
                 // The SessionId has to be reset if the option for logging data is changed to prevent logging without a session id. 
                 // In other words, a new session has to be started.
+                ThreadHelper.ThrowIfNotOnUIThread();
                 if (value)
                 {
                     SubscribeEvents.OnSessionStart();
+                    SubscribeEvents.OnProjectOpen();
                 }
                 else
                 {
                     SubscribeEvents.OnSessionEnd();
+                    SubscribeEvents.OnProjectClose();
                 }
 
                 _doLogData = value;

--- a/PatternPal/PatternPal.LoggingServer/appsettings.Development.json
+++ b/PatternPal/PatternPal.LoggingServer/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "ConnectionStrings": {
-    "PostgresConnection": "Server=localhost:5432;Username=postgres;Database=postgres;Password=postgres"
+    "PostgresConnection": "Server=postgres;Username=postgres;Database=postgres;Password=postgres"
   }
 }


### PR DESCRIPTION
Fixed 2 bugs:
1. Grpc Error when multiple projects were opened at the same time and thus multiple requests based on the same request was sent.
2. OnSessionStart called twice at initialization