### PR TITLE
CLI: Remove .NET Framework dependency and use Spectre.Console

### DIFF
--- a/PatternPal/PatternPal.Console/PatternPal.ConsoleApp.csproj
+++ b/PatternPal/PatternPal.Console/PatternPal.ConsoleApp.csproj
@@ -3,36 +3,22 @@
     <TargetFramework>net7.0</TargetFramework>
     <Authors>PatternPal</Authors>
     <OutputType>Exe</OutputType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\PatternPal.CommonResources\PatternPal.CommonResources.csproj" />
     <ProjectReference Include="..\PatternPal.Core\PatternPal.Core.csproj" />
-    <ProjectReference Include="..\PatternPal.Recognizers\PatternPal.Recognizers.csproj" />
-    <ProjectReference Include="..\PatternPal.SyntaxTree\PatternPal.SyntaxTree.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.5.0" />
-    <PackageReference Include="NDesk.Options" Version="0.2.1" />
+    <PackageReference Include="Spectre.Console" Version="0.47.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
+    <PackageReference Include="Spectre.Console.Json" Version="0.47.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="System.Composition" Version="7.0.0" />
-    <PackageReference Include="System.Composition.AttributedModel" Version="7.0.0" />
-    <PackageReference Include="System.Composition.Convention" Version="7.0.0" />
-    <PackageReference Include="System.Composition.Hosting" Version="7.0.0" />
-    <PackageReference Include="System.Composition.Runtime" Version="7.0.0" />
-    <PackageReference Include="System.Composition.TypedParts" Version="7.0.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="7.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="7.0.1" />

--- a/PatternPal/PatternPal.Console/Program.cs
+++ b/PatternPal/PatternPal.Console/Program.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text.Encodings.Web;
@@ -9,226 +10,123 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 
-using NDesk.Options;
-
 using PatternPal.Core;
-using PatternPal.Core.Recognizers;
 using PatternPal.Protos;
+
+using Spectre.Console;
+using Spectre.Console.Cli;
+using Spectre.Console.Json;
 
 #endregion
 
 namespace PatternPal.ConsoleApp;
 
-internal static class Program
+// ReSharper disable once ClassNeverInstantiated.Global
+internal sealed class PatternPalCommand : Command< Settings >
 {
-    /// <summary>
-    ///     Prints the parses commandline input and starts the runner
-    /// </summary>
-    /// <param name="args">Takes in commandline options and .cs files</param>
-    private static void Main(
-        string[ ] args)
+    public override int Execute(
+        CommandContext context,
+        Settings settings)
     {
-        IDictionary< Recognizer, IRecognizer > supportedRecognizers = RecognizerRunner.SupportedRecognizers;
-        bool showHelp = false;
-        List< IRecognizer > selectedRecognizers = new();
         FileManager fileManager = new();
 
-        OptionSet options = new()
-                            {
-                                {
-                                    "h|help", "shows this message and exit", v => showHelp = v != null
-                                }
-                            };
+        FileAttributes attributes = File.GetAttributes(settings.FileOrDirectory);
+        List< string > selectedFiles = (attributes & FileAttributes.Directory) == FileAttributes.Directory
+            ? fileManager.GetAllCSharpFilesFromDirectory(settings.FileOrDirectory)
+            : new List< string >
+              {
+                  settings.FileOrDirectory
+              };
 
-        //Add design patterns as specifiable option
-        foreach (IRecognizer recognizer in supportedRecognizers.Values)
-        {
-            options.Add(
-                recognizer.Name.Replace(
-                    " ",
-                    "_"),
-                "includes " + recognizer.Name,
-                // This closure is not stored, so accessing the captured variable is not an issue.
-                // ReSharper disable once AccessToModifiedClosure
-                _ => selectedRecognizers.Add(recognizer)
-            );
-        }
-
-        if (args.Length <= 0)
-        {
-            Console.WriteLine("No arguments or files specified\n");
-            ShowHelpMessage(options);
-            Console.WriteLine("\nYou can write the argument in the console:");
-            string input = Console.ReadLine();
-            if (input == null)
-            {
-                return;
-            }
-
-            args = SplitCommandLine(input).ToArray();
-            if (args.Length <= 0)
-            {
-                return;
-            }
-        }
-
-        List< string > arguments = options.Parse(args);
-
-        if (showHelp)
-        {
-            ShowHelpMessage(options);
-            return;
-        }
-
-        List< string > selectedFiles = (from a in arguments where a.EndsWith(".cs") && a.Length > 3 select a).ToList();
-
-        foreach (string arg in from arg in arguments
-            where Directory.Exists(arg)
-            select arg)
-        {
-            selectedFiles.AddRange(fileManager.GetAllCSharpFilesFromDirectory(arg));
-        }
-
-        if (selectedFiles.Count == 0)
-        {
-            Console.WriteLine("No files specified!");
-            return;
-        }
-
-        //When no specific pattern is chosen, select all
-        if (selectedRecognizers.Count == 0)
-        {
-            selectedRecognizers = supportedRecognizers.Values.ToList();
-        }
-
-        Console.WriteLine("Selected files:");
-
-        foreach (string file in selectedFiles)
-        {
-            Console.WriteLine(" - " + file);
-        }
-
-        Console.WriteLine("\nSelected patterns:");
-
-        foreach (IRecognizer selectedRecognizer in selectedRecognizers)
-        {
-            Console.WriteLine(" - " + selectedRecognizer.Name);
-        }
-
-        Console.WriteLine();
+        AnsiConsole.WriteLine("Selected files:");
+        AnsiConsole.Write(new Rows(selectedFiles.Select(file => new TextPath(file))));
 
         RecognizerRunner recognizerRunner = new(
             selectedFiles,
-            selectedRecognizers );
+            new[ ]
+            {
+                settings.Pattern
+            } );
 
         IList< ICheckResult > result = recognizerRunner.Run();
 
-        Console.WriteLine();
-        PrintResults(
-            result);
-    }
-
-    private static void ShowHelpMessage(
-        OptionSet options)
-    {
-        Console.WriteLine("Usage: patterpal [INPUT] [OPTIONS]");
-        Console.WriteLine("Options:");
-        options.WriteOptionDescriptions(Console.Out);
-    }
-
-    private static void PrintResults(
-        IList< ICheckResult > result)
-    {
-        Console.WriteLine("\nResults:");
-
-        Console.WriteLine(
-            JsonSerializer.Serialize(
-                result,
-                new JsonSerializerOptions
+        string jsonOutput = JsonSerializer.Serialize(
+            result,
+            new JsonSerializerOptions
+            {
+                Converters =
                 {
-                    Converters =
-                    {
-                        new JsonStringEnumConverter()
-                    },
-                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-                    WriteIndented = true,
-                    // NOTE: Workaround to ignore the required `ICheckResult.Check` property.
-                    // See: https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/required-properties
-                    TypeInfoResolver = new DefaultJsonTypeInfoResolver
+                    new JsonStringEnumConverter()
+                },
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                WriteIndented = true,
+                // NOTE: Workaround to ignore the required `ICheckResult.Check` property.
+                // See: https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/required-properties
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
+                                   {
+                                       Modifiers =
                                        {
-                                           Modifiers =
+                                           static ti =>
                                            {
-                                               static ti =>
+                                               if (ti.Kind != JsonTypeInfoKind.Object)
                                                {
-                                                   if (ti.Kind != JsonTypeInfoKind.Object)
-                                                   {
-                                                       return;
-                                                   }
+                                                   return;
+                                               }
 
-                                                   foreach (JsonPropertyInfo propertyInfo in ti.Properties)
-                                                   {
-                                                       propertyInfo.IsRequired = false;
-                                                   }
+                                               foreach (JsonPropertyInfo propertyInfo in ti.Properties)
+                                               {
+                                                   propertyInfo.IsRequired = false;
                                                }
                                            }
                                        }
-                }));
-        Console.WriteLine();
+                                   }
+            });
+
+        AnsiConsole.WriteLine("Results:");
+        AnsiConsole.Write(new JsonText(jsonOutput));
+
+        return 0;
     }
+}
 
-    private static IEnumerable< string > SplitCommandLine(
-        string commandLine)
+// ReSharper disable once ClassNeverInstantiated.Global
+internal sealed class Settings : CommandSettings
+{
+    [Description("Pattern to recognize")]
+    [CommandArgument(
+        0,
+        "<Pattern>")]
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global
+    public required Recognizer Pattern { get; init; }
+
+    [Description("File or directory to run the recognizers on")]
+    [CommandArgument(
+        1,
+        "<FileOrDirectory>")]
+    public required string FileOrDirectory { get; set; }
+
+    public override ValidationResult Validate()
     {
-        bool inQuotes = false;
-
-        return commandLine.Split(
-                              c =>
-                              {
-                                  if (c == '\"')
-                                  {
-                                      inQuotes = !inQuotes;
-                                  }
-
-                                  return !inQuotes && c == ' ';
-                              }
-                          )
-                          .Select(arg => arg.Trim().TrimMatchingQuotes('\"'))
-                          .Where(arg => !string.IsNullOrEmpty(arg));
-    }
-
-    private static IEnumerable< string > Split(
-        this string str,
-        Func< char, bool > controller
-    )
-    {
-        int nextPiece = 0;
-
-        for (int c = 0;
-             c < str.Length;
-             c++)
+        ValidationResult baseValidationResult = base.Validate();
+        if (baseValidationResult.Successful)
         {
-            if (controller(str[ c ]))
+            FileOrDirectory = Path.GetFullPath(FileOrDirectory);
+            if (!Path.Exists(FileOrDirectory))
             {
-                yield return str.Substring(
-                    nextPiece,
-                    c - nextPiece);
-                nextPiece = c + 1;
+                throw new InvalidOperationException("File or directory does not exist");
             }
         }
 
-        yield return str[ nextPiece.. ];
+        return baseValidationResult;
     }
+}
 
-    private static string TrimMatchingQuotes(
-        this string input,
-        char quote)
+internal static class Program
+{
+    private static int Main(
+        string[ ] args)
     {
-        return input.Length >= 2
-               && input[ 0 ] == quote
-               && input[ ^1 ] == quote
-            ? input.Substring(
-                1,
-                input.Length - 2)
-            : input;
+        CommandApp< PatternPalCommand > app = new();
+        return app.Run(args);
     }
 }


### PR DESCRIPTION
Instead of `NDesk.Options`, which is .NET Framework only, we now use [`Spectre.Console`](https://spectreconsole.net/) for command line argument parsing and output.