### PR TITLE
Log: File.Edit only logging when enabled

### DIFF
--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -119,6 +119,7 @@ namespace PatternPal.Extension.Commands
             _dteSolutionEvents.BeforeClosing -= OnSolutionClose;
             _dteDebugEvents.OnEnterBreakMode -= OnExceptionUnhandled;
             _dteDebugEvents.OnEnterDesignMode -= OnDebugProgram;
+            _dteDocumentEvents.DocumentSaved -= OnDocumentSaved;
         }
 
 


### PR DESCRIPTION
Fixed: File.Edit logged regardless whether the user had specified to enable or disable logging.
