### PR TITLE
Rec: Always prune child results before parent

### DIFF
--- a/PatternPal/PatternPal.Core/RecognizerRunner.cs
+++ b/PatternPal/PatternPal.Core/RecognizerRunner.cs
@@ -305,10 +305,13 @@ public class RecognizerRunner
                 {
                     // Filter the results recursively. If `PruneResults` returns true, the node
                     // check itself should also be pruned.
-                    if (Prune(nodeCheckResult.Priority, pruneAll) && PruneResults(
-                        resultsByNode,
-                        nodeCheckResult,
-                        pruneAll))
+                    if (PruneResults(
+                            resultsByNode,
+                            nodeCheckResult,
+                            pruneAll)
+                        && Prune(
+                            nodeCheckResult.Priority,
+                            pruneAll))
                     {
                         resultsToBePruned.Add(nodeCheckResult);
                         nodeCheckResult.Pruned = true;

--- a/PatternPal/PatternPal.Tests/Core/RecognizerRunnerTests/RecognizerRunnerTests.Incorrect_Relation_Result_Is_Pruned.verified.txt
+++ b/PatternPal/PatternPal.Tests/Core/RecognizerRunnerTests/RecognizerRunnerTests.Incorrect_Relation_Result_Is_Pruned.verified.txt
@@ -1,0 +1,84 @@
+﻿{
+  FeedbackMessage: Found the required checks for: C1.,
+  Priority: High,
+  ChildrenCheckResults: [
+    {
+      FeedbackMessage: ,
+      ChildrenCheckResults: [
+        {
+          FeedbackMessage: Found class 'C2',
+          ChildrenCheckResults: [
+            {
+              FeedbackMessage: Modifiers correctly implemented.,
+              Correct: true,
+              MatchedNode: C2
+            }
+          ],
+          MatchedNode: C2,
+          NodeCheckCollectionWrapper: false
+        }
+      ],
+      CollectionKind: Any,
+      NodeCheckCollectionWrapper: true
+    },
+    {
+      FeedbackMessage: ,
+      Priority: High,
+      ChildrenCheckResults: [
+        {
+          FeedbackMessage: Found class 'C1',
+          Priority: High,
+          DependencyCount: 1,
+          MatchedNode: C1,
+          NodeCheckCollectionWrapper: false
+        },
+        {
+          FeedbackMessage: Found class 'C2',
+          Priority: High,
+          DependencyCount: 1,
+          MatchedNode: C2,
+          NodeCheckCollectionWrapper: false
+        },
+        {
+          FeedbackMessage: Found class 'C3',
+          Priority: High,
+          ChildrenCheckResults: [
+            {
+              FeedbackMessage: ,
+              ChildrenCheckResults: [
+                {
+                  FeedbackMessage: Found constructor: C3().,
+                  ChildrenCheckResults: [
+                    {
+                      FeedbackMessage: Found Creates relations for C3().,
+                      Priority: High,
+                      CollectionKind: Any,
+                      DependencyCount: 1,
+                      MatchedNode: C3,
+                      NodeCheckCollectionWrapper: true
+                    }
+                  ],
+                  DependencyCount: 1,
+                  MatchedNode: C3,
+                  NodeCheckCollectionWrapper: false
+                }
+              ],
+              CollectionKind: Any,
+              DependencyCount: 1,
+              NodeCheckCollectionWrapper: true
+            }
+          ],
+          DependencyCount: 1,
+          MatchedNode: C3,
+          NodeCheckCollectionWrapper: false
+        }
+      ],
+      CollectionKind: Any,
+      DependencyCount: 1,
+      NodeCheckCollectionWrapper: true
+    }
+  ],
+  DependencyCount: 1,
+  MatchedNode: C1,
+  NodeCheckCollectionWrapper: false
+}


### PR DESCRIPTION
The decision whether the parent should be pruned should only be made after its children have been pruned. If we do that check first, and we decide not the prune the parent, we forget to prune its children.