### PR TITLE
QA: Reviewed PatternPal.Tests

### DIFF
--- a/PatternPal/PatternPal.Tests/BackgroundService/ServiceTests.cs
+++ b/PatternPal/PatternPal.Tests/BackgroundService/ServiceTests.cs
@@ -5,8 +5,6 @@ using System.IO;
 using Grpc.Core;
 using Grpc.Net.Client;
 
-using NUnit.Framework;
-
 using PatternPal.Protos;
 
 #endregion

--- a/PatternPal/PatternPal.Tests/Checks/ClassCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/ClassCheckTests.cs
@@ -1,12 +1,4 @@
-﻿#region
-
-using PatternPal.SyntaxTree.Abstractions.Entities;
-
-using static PatternPal.Core.Checks.CheckBuilder;
-
-#endregion
-
-namespace PatternPal.Tests.Checks;
+﻿namespace PatternPal.Tests.Checks;
 
 [TestFixture]
 public class ClassCheckTests

--- a/PatternPal/PatternPal.Tests/Checks/ConstructorCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/ConstructorCheckTests.cs
@@ -1,10 +1,4 @@
-﻿#region
-
-using static PatternPal.Core.Checks.CheckBuilder;
-
-#endregion
-
-namespace PatternPal.Tests.Checks;
+﻿namespace PatternPal.Tests.Checks;
 
 internal class ConstructorCheckTests
 {

--- a/PatternPal/PatternPal.Tests/Checks/FieldCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/FieldCheckTests.cs
@@ -1,10 +1,4 @@
-﻿#region
-
-using static PatternPal.Core.Checks.CheckBuilder;
-
-#endregion
-
-namespace PatternPal.Tests.Checks
+﻿namespace PatternPal.Tests.Checks
 {
     public class FieldCheckTests
     {

--- a/PatternPal/PatternPal.Tests/Checks/InterfaceCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/InterfaceCheckTests.cs
@@ -1,8 +1,4 @@
-﻿#region
-
-#endregion
-
-namespace PatternPal.Tests.Checks;
+﻿namespace PatternPal.Tests.Checks;
 
 [TestFixture]
 public class InterfaceCheckTests

--- a/PatternPal/PatternPal.Tests/Checks/MethodCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/MethodCheckTests.cs
@@ -1,10 +1,4 @@
-﻿#region
-
-using static PatternPal.Core.Checks.CheckBuilder;
-
-#endregion
-
-namespace PatternPal.Tests.Checks;
+﻿namespace PatternPal.Tests.Checks;
 
 internal class MethodCheckTests
 {

--- a/PatternPal/PatternPal.Tests/Checks/ModifierCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/ModifierCheckTests.cs
@@ -1,6 +1,5 @@
 ﻿#region
 
-using PatternPal.SyntaxTree.Abstractions.Entities;
 using PatternPal.SyntaxTree.Abstractions.Root;
 
 #endregion

--- a/PatternPal/PatternPal.Tests/Checks/NotCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/NotCheckTests.cs
@@ -1,10 +1,4 @@
-﻿#region
-
-using PatternPal.SyntaxTree.Abstractions.Entities;
-
-#endregion
-
-namespace PatternPal.Tests.Checks;
+﻿namespace PatternPal.Tests.Checks;
 
 internal class NotCheckTests
 {

--- a/PatternPal/PatternPal.Tests/Checks/ParameterCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/ParameterCheckTests.cs
@@ -1,8 +1,4 @@
-﻿#region
-
-#endregion
-
-namespace PatternPal.Tests.Checks;
+﻿namespace PatternPal.Tests.Checks;
 
 [TestFixture]
 public class ParameterCheckTests

--- a/PatternPal/PatternPal.Tests/Checks/PropertyCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/PropertyCheckTests.cs
@@ -1,8 +1,4 @@
-﻿#region
-
-#endregion
-
-namespace PatternPal.Tests.Checks;
+﻿namespace PatternPal.Tests.Checks;
 
 internal class PropertyCheckTests
 {

--- a/PatternPal/PatternPal.Tests/Checks/RelationCheckTests.cs
+++ b/PatternPal/PatternPal.Tests/Checks/RelationCheckTests.cs
@@ -1,10 +1,4 @@
-﻿#region
-
-using static PatternPal.Core.Checks.CheckBuilder;
-
-#endregion
-
-namespace PatternPal.Tests.Checks;
+﻿namespace PatternPal.Tests.Checks;
 
 [TestFixture]
 public class RelationCheckTests

--- a/PatternPal/PatternPal.Tests/Core/FileManagerTest.cs
+++ b/PatternPal/PatternPal.Tests/Core/FileManagerTest.cs
@@ -1,6 +1,4 @@
-﻿using NUnit.Framework;
-
-namespace PatternPal.Tests.Core
+﻿namespace PatternPal.Tests.Core
 {
     internal class FileManagerTest
     {

--- a/PatternPal/PatternPal.Tests/Core/GenerateSyntaxTreeTest.cs
+++ b/PatternPal/PatternPal.Tests/Core/GenerateSyntaxTreeTest.cs
@@ -1,15 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using NUnit.Framework;
-using PatternPal.SyntaxTree.Abstractions.Entities;
-
-namespace PatternPal.Tests.Core
+﻿namespace PatternPal.Tests.Core
 {
     internal class GenerateSyntaxTreeTest
     {
-        private readonly Dictionary<string, IEntity> entityNodes =
-            new Dictionary<string, IEntity>();
-
-
         [TestCase(
             @"namespace TestNamespace {
                     class TestClass {
@@ -200,9 +192,9 @@ namespace PatternPal.Tests.Core
         )]
         public void TestIfAmountOfUsingsIsRight(string file, int amountOfUsings)
         {
-            var graph = new SyntaxGraph();
+            SyntaxGraph graph = new SyntaxGraph();
             graph.AddFile(file, "testFile");
-            var count = graph.GetRoots().SelectMany(r => r.GetUsing()).Count();
+            int count = graph.GetRoots().SelectMany(r => r.GetUsing()).Count();
 
             Assert.AreEqual(amountOfUsings, count);
         }

--- a/PatternPal/PatternPal.Tests/Core/RecognizerRunnerTests/RecognizerRunnerTests.cs
+++ b/PatternPal/PatternPal.Tests/Core/RecognizerRunnerTests/RecognizerRunnerTests.cs
@@ -1,6 +1,4 @@
-﻿using PatternPal.SyntaxTree.Models.Entities;
-
-namespace PatternPal.Tests.Core.RecognizerRunnerTests;
+﻿namespace PatternPal.Tests.Core.RecognizerRunnerTests;
 
 [TestFixture]
 public class RecognizerRunnerTests

--- a/PatternPal/PatternPal.Tests/Core/RelationTest.cs
+++ b/PatternPal/PatternPal.Tests/Core/RelationTest.cs
@@ -1,6 +1,4 @@
-﻿using PatternPal.SyntaxTree.Abstractions.Entities;
-
-namespace PatternPal.Tests.Core;
+﻿namespace PatternPal.Tests.Core;
 
 public class RelationTest
 {

--- a/PatternPal/PatternPal.Tests/NodeConverter.cs
+++ b/PatternPal/PatternPal.Tests/NodeConverter.cs
@@ -37,7 +37,6 @@ public class NodeConverter : JsonConverter
         VerifierSettings.IgnoreMember("Pruned");
         VerifierSettings.IgnoreMember("Check");
         VerifierSettings.IgnoreMember("RelatedCheck");
-        
     }
 
 }

--- a/PatternPal/PatternPal.Tests/Utils/EntityNodeUtils.cs
+++ b/PatternPal/PatternPal.Tests/Utils/EntityNodeUtils.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.CodeAnalysis;
 
-using PatternPal.SyntaxTree.Abstractions.Entities;
 using PatternPal.SyntaxTree.Abstractions.Root;
 using PatternPal.SyntaxTree.Models.Entities;
 using PatternPal.SyntaxTree.Models.Members.Field;

--- a/PatternPal/PatternPal.Tests/Utils/FileUtils.cs
+++ b/PatternPal/PatternPal.Tests/Utils/FileUtils.cs
@@ -1,4 +1,8 @@
-﻿using System.IO;
+﻿#region
+
+using System.IO;
+
+#endregion
 
 namespace PatternPal.Tests.Utils
 {
@@ -29,8 +33,8 @@ namespace PatternPal.Tests.Utils
         /// <returns>List with all file contents </returns>
         public static List<string> FilesToString(string folderPath)
         {
-            var filesContents = new List<string>();
-            foreach (var file in Directory.EnumerateFiles("TestClasses\\" + folderPath, "*.cs"))
+            List<string> filesContents = new();
+            foreach (string file in Directory.EnumerateFiles("TestClasses\\" + folderPath, "*.cs"))
             {
                 filesContents.Add(File.ReadAllText(file));
             }

--- a/PatternPal/PatternPal.Tests/Utils/RecognizerContext4Tests.cs
+++ b/PatternPal/PatternPal.Tests/Utils/RecognizerContext4Tests.cs
@@ -1,6 +1,4 @@
-﻿using PatternPal.SyntaxTree.Abstractions.Entities;
-
-namespace PatternPal.Tests.Utils;
+﻿namespace PatternPal.Tests.Utils;
 
 internal class RecognizerContext4Tests : IRecognizerContext
 {

--- a/PatternPal/PatternPal.Tests/Utils/RootNode4Tests.cs
+++ b/PatternPal/PatternPal.Tests/Utils/RootNode4Tests.cs
@@ -1,6 +1,10 @@
-﻿using Microsoft.CodeAnalysis;
+﻿#region
+
+using Microsoft.CodeAnalysis;
 
 using PatternPal.SyntaxTree.Abstractions.Root;
+
+#endregion
 
 namespace PatternPal.Tests.Utils;
 

--- a/PatternPal/PatternPal.Tests/Utils/TestRecognizer.cs
+++ b/PatternPal/PatternPal.Tests/Utils/TestRecognizer.cs
@@ -1,7 +1,12 @@
-﻿using PatternPal.Core.StepByStep;
+﻿#region
+
+using PatternPal.Core.StepByStep;
+
+#endregion
 
 namespace PatternPal.Tests.Utils;
 
+// TODO These are utils, so I'd like to see them commented.
 internal class TestRecognizerRelation : IRecognizer
 {
     public string Name => nameof(TestRecognizerRelation);

--- a/PatternPal/PatternPal.Tests/Utils/TestRecognizer.cs
+++ b/PatternPal/PatternPal.Tests/Utils/TestRecognizer.cs
@@ -1,18 +1,19 @@
-﻿#region
+﻿namespace PatternPal.Tests.Utils;
 
-using PatternPal.Core.StepByStep;
 
-#endregion
-
-namespace PatternPal.Tests.Utils;
-
-// TODO These are utils, so I'd like to see them commented.
+/// <summary>
+/// A recognizer that can be used to test the <see cref="RelationCheck"/> of <see cref="RelationType.Uses"/>
+/// between a class and a method
+/// </summary>
 internal class TestRecognizerRelation : IRecognizer
 {
+    /// <inheritdoc />
     public string Name => nameof(TestRecognizerRelation);
 
+    /// <inheritdoc />
     public Protos.Recognizer RecognizerType => Protos.Recognizer.Unknown;
 
+    /// <inheritdoc />
     public IEnumerable<ICheck> Create()
     {
         MethodCheck instanceMethod =
@@ -37,19 +38,20 @@ internal class TestRecognizerRelation : IRecognizer
             )
         );
     }
-
-    public List<IInstruction> GenerateStepsList()
-    {
-        throw new NotImplementedException();
-    }
 }
 
+/// <summary>
+/// A recognizer that can be used to test the <see cref="TypeCheck"/> in combination with a <see cref="MethodCheck"/>
+/// </summary>
 internal class TestRecognizerType : IRecognizer
 {
+    /// <inheritdoc />
     public string Name => nameof(TestRecognizerType);
 
+    /// <inheritdoc />
     public Protos.Recognizer RecognizerType => Protos.Recognizer.Unknown;
 
+    /// <inheritdoc />
     public IEnumerable<ICheck> Create()
     {
         ClassCheck internalClass = Class(
@@ -72,10 +74,5 @@ internal class TestRecognizerType : IRecognizer
                 )
             )
         );
-    }
-
-    public List<IInstruction> GenerateStepsList()
-    {
-        throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
- Removed many unused `using`-directives
- Factored out some `var`'s
- Many tests are totally uncommented; leaving that for now
- I still feel like it is better practice to remove all testcases _at least_ from the building-process of PatternPal; will mark that as a future `TODO`