### PR TITLE
Log: Fixed FileWatcher-related bugs

### DIFF
--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -202,19 +202,12 @@ namespace PatternPal.Extension.Commands
         }
 
         /// <summary>
-        /// The event handler for handling the File.Create Event. The file watcher detects every file created,
-        /// so any event triggers with files other than .cs files are unhandled.    
+        /// The event handler for handling the File.Create Event.
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="fileSystemEventArgs"></param>
         internal static void OnFileCreate(object sender, FileSystemEventArgs fileSystemEventArgs)
         {
-            // Only log for the creation of .cs files
-            if (Path.GetExtension(fileSystemEventArgs.Name) != ".cs")
-            {
-                return;
-            }
-
             LogEventRequest request = CreateStandardLog();
             request.EventType = EventType.EvtFileCreate;
             request.CodeStateSection = fileSystemEventArgs.Name;
@@ -226,15 +219,15 @@ namespace PatternPal.Extension.Commands
         }
 
         /// <summary>
-        /// The event handler for handling the File.Delete Event. The file watcher detects every file deleted,
-        /// so any event triggers with files other than .cs files are unhandled.    
+        /// The event handler for handling the File.Delete Event.
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="fileSystemEventArgs"></param>
         internal static void OnFileDelete(object sender, FileSystemEventArgs fileSystemEventArgs)
         {
-            // Only log for the creation of .cs files
-            if (Path.GetExtension(fileSystemEventArgs.Name) != ".cs")
+            // Other operations might also cause the fileWatcher to fire this event, so we explicitly check if the file
+            // does not exist anymore.
+            if (File.Exists(fileSystemEventArgs.FullPath))
             {
                 return;
             }
@@ -475,7 +468,7 @@ namespace PatternPal.Extension.Commands
 
             // Create a new FileSystemWatcher instance
             // TODO We need to explicitely check if that path is not null and handle other cases.
-            _watcher = new FileSystemWatcher(Path.GetDirectoryName(_currentSolution.FullName));
+            _watcher = new FileSystemWatcher(Path.GetDirectoryName(_currentSolution.FullName), "*.cs");
 
             // Set the event handlers
             _watcher.Created += OnFileCreate;


### PR DESCRIPTION
- Included a filter in the `FileWatcher`, excluding all non `.cs`-files. Besides now being centralised rather than handled per event, this also optimises the performance of the watcher itself.
- Fixed accidental `File.Delete`-triggers when files were edited by explicitly checking if the file has actually seized to exists. However, this bug could have been predicted by following the warnings in the `FileWatcher`-documentation.
- Fixed `File.Create`- and `File.Delete`-triggers while building/cleaning a project/solution for`.cs`-files contained in the build artifacts.