### PR TITLE
Log: Optimized FileWatcher-set-up

### DIFF
--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -549,9 +549,9 @@ namespace PatternPal.Extension.Commands
 
             // Create new watcher, subscribe events and set properties
             string solutionDirectory = Path.GetDirectoryName(_dte.Solution.FullName);
-            if (solutionDirectory == null)
+            if (solutionDirectory == null || !Directory.Exists(solutionDirectory))
             {
-                // We shouldn't set up the watcher if the solutionDirectory is null; however, it is known to be not null here, so this is is just a safety measure.
+                // We shouldn't set up the watcher if the solutionDirectory is null or non-existent; however, it is known to be not null here, so this is is just a safety measure.
                 return;
             }
             _watcher = new FileSystemWatcher(solutionDirectory, "*.cs");

--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -353,7 +353,6 @@ namespace PatternPal.Extension.Commands
         /// </summary>
         internal static void OnSolutionClose()
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
             LogEachProject(EventType.EvtProjectClose);
 
             // We should dispose of the watcher here; just for safety, we add a null check.
@@ -509,6 +508,7 @@ namespace PatternPal.Extension.Commands
         private static void LogEachProject(EventType eventType)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
+
             Projects projects = _dte.Solution.Projects;
 
             foreach (Project project in projects)

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -1,4 +1,4 @@
-#region
+﻿#region
 
 using Google.Protobuf;
 using System.IO.Compression;
@@ -69,13 +69,14 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
             };
             taskResult.Message = e.Message;
         }
+
         catch (Exception e)
         {
             taskResult.Status = Protos.LogStatusCodes.LscFailure;
             taskResult.Message = e.Message;
         }
-        return Task.FromResult(taskResult);
 
+        return Task.FromResult(taskResult);
     }
 
     /// <summary>


### PR DESCRIPTION
- Removed redundant private fields in `SubscribeEvents.cs`
- Centralised setting/unsetting the `fileWatcher`
- Prevented setting up the `fileWatcher` when the supplied path was non-existent