### PR TITLE
Docs: Developer documentation for adding InstructionSet for SBS.

### DIFF
--- a/docs/dev/stepbystep/guides/implement_an_instructionset.md
+++ b/docs/dev/stepbystep/guides/implement_an_instructionset.md
@@ -4,19 +4,21 @@ To support a design pattern in PatternPal one must implement the `IStepByStepRec
 This interface defines a `string` `Name`, a `RecognizerType` as defined in the protocol buffer and 
 a method `GenerateStepsList`, which will return the object required of the Step-By-Step module.
 
-In order to make effective use of existing `Recognizers` for bot detecting patterns and Step-By-Step 
+# Efficiently add to `Recognizer` functionality
+
+In order to make effective use of existing `Recognizers` for both detecting patterns and Step-By-Step 
 it is recommended to encase the `IChecks` created in the `Recognizer's` `Create` method 
-([here](~/dev/recognizers/guides/implement_recognizer.md)) into separate methods. This way the checks can
+(more on this method can be found [here](~/dev/recognizers/guides/implement_recognizer.md)) into separate methods. This way the checks can
 be declared once and can be called in both `Create` in `IRecognizer` and in `GenerateStepsList` in 
-`IStepByStepRecognizer`. 
- 
+`IStepByStepRecognizer`. The Recognizers would then inherit from both recognizer interfaces (`IRecognizer` 
+and `IStepByStepRecognizer`).
 
 ## Prerequisites 
 
 First, it is of utmost importance that one has a clear idea of how much is asked of the user per step. It 
 is  preferred to make the steps small and that they are supported by the available `ICheck`s 
-([here](~/dev/recognizers/design/checks.md)). Second, it is important to have an explanation to 
-communicate to the user what is required to pass the step and optionally and explanation why the 
+(available checks can be found [here](~/dev/recognizers/design/checks.md)). Second, it is important to have an explicit instruction to 
+communicate to the user what is required to pass the step and optionally an explanation why the 
 requirement is the way it is. 
 
 ## Implementing the GenerateStepsList method
@@ -51,3 +53,105 @@ internal class MyStepBySteps : IStepByStepRecognizer
 ```
 
 ## Implementing the method
+The return type is a list of `IInstruction`s. These instructions require a `string Requirement` 
+(the previously mentioned explicit instruction), `string Description` (the previously mentioned explanation) 
+and a list of `ICheck`s that reflect the requirement of the step. 
+
+The `Requirement` and `Description` are retrieved from the resources (`.resx` files). These are to be added 
+to the `PatternPal.Core` project under the folder `StepByStep\Resources\Instructions`. For example: 
+"`SingletonInstructions.resx`". Per step a `Requirement` string and `Description` string can be added to 
+this resource.
+
+Creating an `IInstruction` should lastly be supplied with a list of `ICheck`s that need to pass in a step. 
+These can be added to a list of instruction in `GenerateStepsList`. An example would be :
+
+```csharp
+
+List< IInstruction > IStepByStepRecognizer.GenerateStepsList()
+{
+	List< IInstruction > generateStepsList = new();
+	
+	// Step 1: There is a static private field with the same type as the class
+	generateStepsList.Add(
+            new SimpleInstruction(
+                SingletonInstructions.Step1,
+                SingletonInstructions.Explanation1,
+                new List< ICheck >
+				{
+					Class(
+						Priority.Knockout,
+						Field(
+							Priority.Knockout,
+							"Has a static, private field with the same type as the class",
+							Modifiers(
+								Priority.Knockout,
+								Modifier.Static,
+								Modifier.Private
+							),
+							Type(
+								Priority.Knockout,
+								ICheck.GetCurrentEntity
+							)
+						)
+					)
+				}
+            ));
+	
+	// Step 2: ...
+	...
+	
+	return generateStepsList;
+}
+```
+
+When the `IStepByStepRecognizer` interface is implemented it is automatically added as an option to the 
+extension. It can then be selected from the combobox in the `StepByStepListView`.
+
+## Final Code
+
+```csharp
+using static PatternPal.Core.StepByStep;
+using static PatternPal.Core.StepByStep.Resources.Instructions;
+
+namespace MyStepBySteps;
+
+internal class MyStepBySteps : IStepByStepRecognizer
+{
+	public string Name => "Singleton";
+	
+	public Recognizer RecognizerType => Recognizer.Singleton;
+	
+	List< IInstruction > IStepByStepRecognizer.GenerateStepsList()
+	{
+		List< IInstruction > generateStepsList = new();
+		
+		// Step 1: There is a static private field with the same type as the class
+		generateStepsList.Add(
+				new SimpleInstruction(
+					SingletonInstructions.Step1,
+					SingletonInstructions.Explanation1,
+					new List< ICheck >
+					{
+						Class(
+							Priority.Knockout,
+							Field(
+								Priority.Knockout,
+								"Has a static, private field with the same type as the class",
+								Modifiers(
+									Priority.Knockout,
+									Modifier.Static,
+									Modifier.Private
+								),
+								Type(
+									Priority.Knockout,
+									ICheck.GetCurrentEntity
+								)
+							)
+						)
+					}
+				));
+		
+		return generateStepsList;
+	}
+}
+```

--- a/docs/dev/stepbystep/guides/implement_an_instructionset.md
+++ b/docs/dev/stepbystep/guides/implement_an_instructionset.md
@@ -32,9 +32,8 @@ The entity to be implemented (e.g. fields/methods/classes/interfaces) requires a
 states explicitly what needs to be implemented and what the underlying `ICheck` will test for. For example: 
 "Implement a static private field of the same type as the class". 
 
-In addition a `Description` of the step 
-for education purposes should be provided that explains why the one should implement as instructed for example:
-"The field is static as a way of accessing the single instance when it is created.".
+For education purposes a `Description` of the step should be provided. It should explain why the step should
+be implemented as instructed for example: "The field is static as a way of accessing the single instance when it is created.".
 
 
 ## The `IStepByStepRecognizer` interface and library requirements

--- a/docs/dev/stepbystep/guides/implement_an_instructionset.md
+++ b/docs/dev/stepbystep/guides/implement_an_instructionset.md
@@ -21,6 +21,22 @@ is  preferred to make the steps small and that they are supported by the availab
 communicate to the user what is required to pass the step and optionally an explanation why the 
 requirement is the way it is. 
 
+### Requirement and explanation per step
+The goal is to make a step as small as possible. Defining a single class/interface, a single field, 
+or a single method is considered a step. Defining a method can be more detailed because the behaviour 
+of the method needs to be described (return types, modifiers, parameters), while defining a field is the 
+smallest step (including modifiers). Anything defined in one step should be closed in such a way that you
+don't have to go back the the method/interface/field in a later step. 
+
+The entity to be implemented (e.g. fields/methods/classes/interfaces) requires an explicit `Requirement` that
+states explicitly what needs to be implemented and what the underlying `ICheck` will test for. For example: 
+"Implement a static private field of the same type as the class". 
+
+In addition a `Description` of the step 
+for education purposes should be provided that explains why the one should implement as instructed for example:
+"The field is static as a way of accessing the single instance when it is created.".
+
+
 ## Implementing the GenerateStepsList method
 
 To support a Pattern for Step-By-Step one must add the following `using` statement to the top of 

--- a/docs/dev/stepbystep/guides/implement_an_instructionset.md
+++ b/docs/dev/stepbystep/guides/implement_an_instructionset.md
@@ -68,6 +68,37 @@ internal class MyStepBySteps : IStepByStepRecognizer
 }
 ```
 
+## The `SimpleInstruction` object
+Everything that is required by the program to retrieve information for a step and display that to the user 
+is encased in `SimpleInstruction`s. These are the `Requirement`, `Description` and a list of `ICheck`s. An 
+example of a `SimpleInstruction` would be: 
+
+```csharp
+new SimpleInstruction(
+                "Implement a...",
+                "You have to implement it this way because...",
+                new List< ICheck >
+				{
+					Class(
+						Priority.Knockout,
+						Field(
+							Priority.Knockout,
+							"Feedback message",
+							Modifiers(
+								Priority.Knockout,
+								Modifier.Static,
+								Modifier.Private
+							),
+							Type(
+								Priority.Knockout,
+								ICheck.GetCurrentEntity
+							)
+						)
+					)
+				}
+            )
+```
+
 ## Implementing the `GenerateStepsList` method
 The return type is a list of `IInstruction`s. These instructions require a `string Requirement` 
 (the previously mentioned explicit instruction), `string Description` (the previously mentioned explanation) 

--- a/docs/dev/stepbystep/guides/implement_an_instructionset.md
+++ b/docs/dev/stepbystep/guides/implement_an_instructionset.md
@@ -37,7 +37,7 @@ for education purposes should be provided that explains why the one should imple
 "The field is static as a way of accessing the single instance when it is created.".
 
 
-## Implementing the GenerateStepsList method
+## The `IStepByStepRecognizer` interface and library requirements
 
 To support a Pattern for Step-By-Step one must add the following `using` statement to the top of 
 file and implement `IStepByStepRecognizer`:
@@ -68,7 +68,7 @@ internal class MyStepBySteps : IStepByStepRecognizer
 }
 ```
 
-## Implementing the method
+## Implementing the `GenerateStepsList` method
 The return type is a list of `IInstruction`s. These instructions require a `string Requirement` 
 (the previously mentioned explicit instruction), `string Description` (the previously mentioned explanation) 
 and a list of `ICheck`s that reflect the requirement of the step. 

--- a/docs/dev/stepbystep/guides/implement_an_instructionset.md
+++ b/docs/dev/stepbystep/guides/implement_an_instructionset.md
@@ -1,0 +1,53 @@
+# Implement an InstructionSet
+
+To support a design pattern in PatternPal one must implement the `IStepByStepRecognizer` interface. 
+This interface defines a `string` `Name`, a `RecognizerType` as defined in the protocol buffer and 
+a method `GenerateStepsList`, which will return the object required of the Step-By-Step module.
+
+In order to make effective use of existing `Recognizers` for bot detecting patterns and Step-By-Step 
+it is recommended to encase the `IChecks` created in the `Recognizer's` `Create` method 
+([here](~/dev/recognizers/guides/implement_recognizer.md)) into separate methods. This way the checks can
+be declared once and can be called in both `Create` in `IRecognizer` and in `GenerateStepsList` in 
+`IStepByStepRecognizer`. 
+ 
+
+## Prerequisites 
+
+First, it is of utmost importance that one has a clear idea of how much is asked of the user per step. It 
+is  preferred to make the steps small and that they are supported by the available `ICheck`s 
+([here](~/dev/recognizers/design/checks.md)). Second, it is important to have an explanation to 
+communicate to the user what is required to pass the step and optionally and explanation why the 
+requirement is the way it is. 
+
+## Implementing the GenerateStepsList method
+
+To support a Pattern for Step-By-Step one must add the following `using` statement to the top of 
+file and implement `IStepByStepRecognizer`:
+
+```csharp
+using static PatternPal.Core.StepByStep;
+using static PatternPal.Core.StepByStep.Resources.Instructions;
+```
+
+The result class should look something like this:
+
+```csharp
+using static PatternPal.Core.StepByStep;
+using static PatternPal.Core.StepByStep.Resources.Instructions;
+
+namespace MyStepBySteps;
+
+internal class MyStepBySteps : IStepByStepRecognizer
+{
+	public string Name => "Singleton";
+	
+	public Recognizer RecognizerType => Recognizer.Singleton;
+	
+	List< IInstruction > IStepByStepRecognizer.GenerateStepsList()
+	{
+		throw new NotImplementedException();
+	}
+}
+```
+
+## Implementing the method

--- a/docs/dev/toc.yml
+++ b/docs/dev/toc.yml
@@ -29,6 +29,8 @@
     href: recognizers/guides/implement_recognizer.md
   - name: Implementing a Check
     href: recognizers/guides/implement_check.md
+  - name: Implementing an InstructionSet
+    href: stepbystep/guides/implement_an_instructionset.md
 
 # Pattern recognition --------------------
 - name: Data logging

--- a/docs/dev/toc.yml
+++ b/docs/dev/toc.yml
@@ -29,7 +29,7 @@
     href: recognizers/guides/implement_recognizer.md
   - name: Implementing a Check
     href: recognizers/guides/implement_check.md
-  - name: Implementing an InstructionSet
+  - name: Adding a design pattern to Step-By-Step
     href: stepbystep/guides/implement_an_instructionset.md
 
 # Pattern recognition --------------------


### PR DESCRIPTION
I have written the developer documentation for adding design patterns to Step-By-Step. I have written it under the assumption that the 'IChecks' are not in individual methods because the GitHub page for "Implement a Recognizer" also does not do this. 

I have added an additional header that strongly suggests encasing the 'IChecks' in different methods to use them for both the Recognizer and Step-By-Step. This can be found under "Efficiently add to `Recognizer` functionality".