### PR TITLE
Docs: Documentation added for usage of Step-By-Step

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,4 +17,11 @@ access PatternPal from `View > Other Windows > PatternPal Extension`.
 
 You can open the main view of the extension through `View > Other Windows > PatternPal Extension`.
 
+### Step-By-Step
+This module offers the flexibility for users to choose between implementing a design pattern from the beginning or continuing their work on a design pattern they have worked on previously. The supported design patterns can be selected from the dropdown menu. 
+
+When the user opts to initiate a new implementation, users are presented with the option to add a file to the current solution or not, in either case, they are subsequently provided with a dialog that asks for the place to save this new file. This new file will then open in Visual Studio. Alternatively, if the user prefers to continue their work they are presented with a dialog to open the file(s) they wish to resume their implementation on. These files(s) are then opened in Visual Studio.
+
+In both options the user is presented with a description of the requirement and explanation of the step. The user should implement the requirement in the opened file and click the 'Check' button. Only when the implementation is correct does the 'next instruction' button become available.
+
 [releases page]: https://github.com/PatternPal/PatternPal/releases/latest

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,10 +18,10 @@ access PatternPal from `View > Other Windows > PatternPal Extension`.
 You can open the main view of the extension through `View > Other Windows > PatternPal Extension`.
 
 ### Step-By-Step
-This module offers the flexibility for users to choose between implementing a design pattern from the beginning or continuing their work on a design pattern they have worked on previously. The supported design patterns can be selected from the dropdown menu. 
+This module offers the flexibility for users to choose between two options: starting the implementation of a new design pattern or continuing their work on a design pattern they have previously worked on.
 
 When the user opts to initiate a new implementation, users are presented with the option to add a file to the current solution or not, in either case, they are subsequently provided with a dialog that asks for the place to save this new file. This new file will then open in Visual Studio. Alternatively, if the user prefers to continue their work they are presented with a dialog to open the file(s) they wish to resume their implementation on. These files(s) are then opened in Visual Studio.
 
-In both options the user is presented with a description of the requirement and explanation of the step. The user should implement the requirement in the opened file and click the 'Check' button. Only when the implementation is correct does the 'next instruction' button become available.
+In both cases the user is presented with a description of the requirement and explanation of the step. The user should implement the requirement in the opened file and click the 'Check' button. Only when the implementation is correct does the 'next instruction' button become available.
 
 [releases page]: https://github.com/PatternPal/PatternPal/releases/latest


### PR DESCRIPTION
I have added usage documentation for the user in the 'Home' page for the GitHub pages. These are the options and use cases for Step-By-Step.