### PR TITLE
SBS: Allowed the user to abort selecting a file in continue and stopped progressing the viewmodel when no files are provided.

### DIFF
--- a/PatternPal/PatternPal.Extension/Commands/NavigateCommand.cs
+++ b/PatternPal/PatternPal.Extension/Commands/NavigateCommand.cs
@@ -1,6 +1,7 @@
 ﻿#region
 
 using System;
+using System.Windows.Documents;
 using System.Windows.Input;
 using PatternPal.Extension.Stores;
 using PatternPal.Extension.ViewModels;
@@ -17,9 +18,10 @@ public class NavigateCommand<T> : ICommand
     /// <summary>
     /// Occurs when changes occur that affect whether or not the command should execute.
     /// </summary>
-#pragma warning disable CS0067
+    #pragma warning disable CS0067
     public event EventHandler CanExecuteChanged;
-#pragma warning restore CS0067
+    #pragma warning restore CS0067
+
     /// <summary>
     /// Gets the navigation store used to manage the current view model.
     /// </summary>
@@ -64,3 +66,64 @@ public class NavigateCommand<T> : ICommand
     }
 }
 
+public class SBScommand<T> : ICommand
+where T : ViewModel
+{
+    /// <summary>
+    /// Occurs when changes occur that affect whether or not the command should execute.
+    /// </summary>
+    #pragma warning disable CS0067
+    public event EventHandler CanExecuteChanged;
+    #pragma warning restore CS0067
+
+    /// <summary>
+    /// Gets the navigation store used to manage the current view model.
+    /// </summary>
+    private NavigationStore NavigationStore { get; }
+
+    /// <summary>
+    /// Gets the function used to create the view model to navigate to.
+    /// </summary>
+    private Func<T> GetViewModel { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NavigateCommand{T}"/> class.
+    /// </summary>
+    /// <param name="navigationStore">The navigation store used to manage the current view model.</param>
+    /// <param name="getViewModel">The function used to create the view model to navigate to.</param>
+    public SBScommand(
+        NavigationStore navigationStore,
+        Func<T> getViewModel)
+    {
+        NavigationStore = navigationStore;
+        GetViewModel = getViewModel;
+    }
+
+    /// <summary>
+    /// Determines whether the command can be executed.
+    /// </summary>
+    /// <param name="parameter">The command parameter.</param>
+    /// <returns>True</returns>
+    public bool CanExecute(object parameter)
+    {
+        return true;
+    }
+
+    /// <summary>
+    /// Executes the command.
+    /// </summary>
+    /// <param name="parameter">The command parameter.</param>
+    public void Execute(object parameter)
+    {
+        T viewModel = GetViewModel();
+
+        // Only proceed to the instructions view when a valid file was provided by the user.
+        if (viewModel is StepByStepInstructionsViewModel stepByStepInstructionsViewModel)
+        {
+            if (stepByStepInstructionsViewModel.FilePaths.Count > 0)
+            {
+                NavigationStore.CurrentViewModel = viewModel;
+            }
+        }
+    }
+}

--- a/PatternPal/PatternPal.Extension/ViewModels/StepByStepListViewModel.cs
+++ b/PatternPal/PatternPal.Extension/ViewModels/StepByStepListViewModel.cs
@@ -69,7 +69,7 @@ namespace PatternPal.Extension.ViewModels
 
             // Next button 
             NavigateStepByStepInstructionsCommand =
-                new NavigateCommand< StepByStepInstructionsViewModel >(
+                new SBScommand< StepByStepInstructionsViewModel >(
                     navigationStore,
                     () => new StepByStepInstructionsViewModel(
                         navigationStore,
@@ -79,7 +79,7 @@ namespace PatternPal.Extension.ViewModels
 
             // Continue button
             NavigateContinueStepByStepInstructionsCommand =
-                new NavigateCommand< StepByStepInstructionsViewModel >(
+                new SBScommand<StepByStepInstructionsViewModel>(
                     navigationStore,
                     () => new StepByStepInstructionsViewModel(
                         navigationStore,
@@ -87,6 +87,7 @@ namespace PatternPal.Extension.ViewModels
                         StepByStepModes.Continue,
                         ContinueButtonBehavior()));
 
+            // Obtain the available instruction sets for Step-By-Step.
             GetInstructionSetsResponse instructionSetsResponse =
                 GrpcHelper.StepByStepClient.GetInstructionSets(new GetInstructionSetsRequest());
 
@@ -101,23 +102,22 @@ namespace PatternPal.Extension.ViewModels
         {
             List< string > result = new List< string >();
 
-            OpenFileDialog ofd = new OpenFileDialog()
-                                 {
-                                     Multiselect = true,
-                                     Filter = "cs files (*.cs)|*.cs",
-                                 };
-
-            while (result.Count == 0)
+            using (CommonOpenFileDialog ofd = new CommonOpenFileDialog
+                   {
+                       Multiselect = true,
+                       Filters = { new CommonFileDialogFilter(
+                           "cs files",
+                           "cs") }
+            })
             {
-                bool ? res = ofd.ShowDialog();
-                if (res.HasValue
-                    && res.Value)
+                CommonFileDialogResult res = ofd.ShowDialog();
+                if (res == CommonFileDialogResult.Ok)
                 {
                     result = ofd.FileNames.ToList();
                 }
                 else
                 {
-                    MessageBox.Show("No files were provided");
+                    MessageBox.Show("No files were provided!");
                 }
             }
 

--- a/PatternPal/PatternPal.Extension/Views/StepByStepInstructionsView.xaml.cs
+++ b/PatternPal/PatternPal.Extension/Views/StepByStepInstructionsView.xaml.cs
@@ -35,7 +35,6 @@ namespace PatternPal.Extension.Views
         {   
             InitializeComponent();
             InitializeViewModelAndButtons();
-            //ContinueButtonBehavior();
 
             Dispatcher.VerifyAccess();
             LoadProject();


### PR DESCRIPTION
Generally, this improves user-friendliness. The infinite loop that keeps asking the user to provide '.cs' files is gone. It gives a message to the user that the provided file was not valid and simply does not progress the view and viewmodel to the instructions. The user can then try again and select either continue or implement a new design pattern. The same is true for not providing a valid file path for saving.