### PR TITLE
Log: Implemented file logging for rename event

### DIFF
--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -193,6 +193,7 @@ namespace PatternPal.Extension.Commands
                 $"Build {action.ToString()} succeeded.";
 
             LogEventRequest request = CreateStandardLog();
+
             string pathSolutionFullName = _dte.Solution.FullName;
             string pathSolutionFile = _dte.Solution.FileName;
 
@@ -254,13 +255,16 @@ namespace PatternPal.Extension.Commands
             }
 
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtFileCreate;
             request.CodeStateSection = fileSystemEventArgs.Name;
+
             string projectFullPath = FindContainingCsprojFile(fileSystemEventArgs.FullPath);
             string projectDirectory = Path.GetDirectoryName(projectFullPath);
             request.ProjectId = GetRelativePath(projectDirectory, projectFullPath);
             request.ProjectDirectory = Path.GetDirectoryName(projectFullPath);
-            request.ProjectId = GetRelativePath(request.ProjectDirectory, projectFullPath);
+            request.ProjectId = GetRelativePath(projectDirectory, projectFullPath);
+
             request.FilePath = fileSystemEventArgs.FullPath;
             
             LogEventResponse response = PushLog(request);
@@ -289,10 +293,13 @@ namespace PatternPal.Extension.Commands
             }
 
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtFileDelete;
             request.CodeStateSection = fileSystemEventArgs.Name;
+
             string projectFullPath = FindContainingCsprojFile(fileSystemEventArgs.FullPath);
             string projectDirectory = Path.GetDirectoryName(projectFullPath);
+            request.ProjectDirectory = projectDirectory;
             request.ProjectId = GetRelativePath(projectDirectory, projectFullPath);
 
             LogEventResponse response = PushLog(request);
@@ -312,13 +319,15 @@ namespace PatternPal.Extension.Commands
             }
 
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtFileRename;
             request.CodeStateSection = e.Name;
             request.OldFileName = e.OldName;
 
             string projectFullPath = FindContainingCsprojFile(e.FullPath);
-            string projectFolderName = Path.GetDirectoryName(projectFullPath);
-            request.ProjectId = GetRelativePath(projectFolderName, projectFullPath);
+            string projectDirectory = Path.GetDirectoryName(projectFullPath);
+            request.ProjectDirectory = projectDirectory;
+            request.ProjectId = GetRelativePath(projectDirectory, projectFullPath);
 
             LogEventResponse response = PushLog(request);
         }
@@ -358,6 +367,7 @@ namespace PatternPal.Extension.Commands
             string sourceLocation, string codeStateSection)
         {
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtCompileError;
             request.ParentEventId = parent.EventId;
             request.CompileMessageType = compileMessagetype;
@@ -396,6 +406,7 @@ namespace PatternPal.Extension.Commands
         private static void OnDebugProgram(dbgEventReason reason)
         {
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtDebugProgram;
             request.ExecutionId = Guid.NewGuid().ToString();
 
@@ -423,8 +434,8 @@ namespace PatternPal.Extension.Commands
             ThreadHelper.ThrowIfNotOnUIThread();
 
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtFileEdit;
-            
             request.CodeStateSection = GetRelativePath(Path.GetDirectoryName(document.FullName), document.FullName);
             request.ProjectId = document.ProjectItem.ContainingProject.UniqueName;
             request.ProjectDirectory = Path.GetDirectoryName(document.ProjectItem.ContainingProject.FullName);
@@ -446,6 +457,7 @@ namespace PatternPal.Extension.Commands
             }
             
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtXRecognizerRun;
             string config = recognizeRequest.Recognizers.ToString();
 
@@ -472,6 +484,7 @@ namespace PatternPal.Extension.Commands
                 return;
             }
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtXStepByStepStep;
             // config should be dict with recognizer name and current instruction number
             Dictionary<string,string> config = new Dictionary<string, string>()

--- a/PatternPal/PatternPal.LoggingServer/Migrations/20230619123815_AddOldFileNameColumn.Designer.cs
+++ b/PatternPal/PatternPal.LoggingServer/Migrations/20230619123815_AddOldFileNameColumn.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PatternPal.LoggingServer.Data;
@@ -11,9 +12,11 @@ using PatternPal.LoggingServer.Data;
 namespace PatternPal.LoggingServer.Migrations
 {
     [DbContext(typeof(ProgSnap2ContextClass))]
-    partial class ProgSnap2ContextClassModelSnapshot : ModelSnapshot
+    [Migration("20230619123815_AddOldFileNameColumn")]
+    partial class AddOldFileNameColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/PatternPal/PatternPal.LoggingServer/Migrations/20230619123815_AddOldFileNameColumn.cs
+++ b/PatternPal/PatternPal.LoggingServer/Migrations/20230619123815_AddOldFileNameColumn.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatternPal.LoggingServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOldFileNameColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OldFileName",
+                table: "Events",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OldFileName",
+                table: "Events");
+        }
+    }
+}

--- a/PatternPal/PatternPal.LoggingServer/Models/ProgSnap2.cs
+++ b/PatternPal/PatternPal.LoggingServer/Models/ProgSnap2.cs
@@ -46,6 +46,7 @@ namespace PatternPal.LoggingServer.Models
         /// <summary>
         /// Whether the stored codeState was complete or partial.
         /// </summary>
+        ///
         public bool? FullCodeState { get; set;  }
 
         /// <summary>
@@ -92,6 +93,11 @@ namespace PatternPal.LoggingServer.Models
         /// The section of the code state associated with this compile event. For example in compile.error, this would be the section of code that caused the error.
         /// </summary>
         public string? CodeStateSection { get; set; }
+
+        /// <summary>
+        ///  The old filename of a file in case of a rename event.
+        /// </summary>
+        public string? OldFileName { get; set; }
 
         /// <summary>
         /// Result in case of debug.run event. Value can be "success", "failure", "timeout", "error", "unknown".

--- a/PatternPal/PatternPal.LoggingServer/Protos/logcollector.proto
+++ b/PatternPal/PatternPal.LoggingServer/Protos/logcollector.proto
@@ -44,6 +44,7 @@ optional string recognizer_result = 24;
 optional string recognizer_config = 25;
 optional bytes data = 26;
 optional bool full_code_state = 27;
+optional string old_file_name = 28;
 }
 
 message LogResponse {

--- a/PatternPal/PatternPal.LoggingServer/Services/LoggerService.cs
+++ b/PatternPal/PatternPal.LoggingServer/Services/LoggerService.cs
@@ -92,6 +92,7 @@ namespace PatternPal.LoggingServer.Services
                 SubjectId = subjectId,
                 ToolInstances = request.ToolInstances,
                 CodeStateId = codeStateId,
+                OldFileName = request.HasOldFileName ? request.OldFileName : null,
                 FullCodeState = request.HasFullCodeState ? request.FullCodeState : null,
                 ClientDatetime = cDto,
                 ServerDatetime = DateTimeOffset.Now,

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -285,23 +285,20 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
         sendLog.OldFileName = receivedRequest.OldFileName;
         sendLog.ProjectId = receivedRequest.ProjectId;
 
+        string oldFilePathInProjectDir = Path.GetRelativePath(receivedRequest.ProjectDirectory, sendLog.OldFileName);
+        string newFilePathInProjectDir = Path.GetRelativePath(receivedRequest.ProjectDirectory, sendLog.CodeStateSection);
         try
         {
             // To rename the key that stores the hash in _lastCodeState, we obtain its value, reinsert it under the new key
             // and delete the old entry.
-            string projectDirectory = Path.GetDirectoryName(sendLog.ProjectId);
-            string oldFilePathInProjectDir = Path.GetRelativePath(projectDirectory, sendLog.OldFileName);
-            string newFilePathInProjectDir = Path.GetRelativePath(projectDirectory, sendLog.CodeStateSection);
-
             string hash = _lastCodeState[sendLog.ProjectId][oldFilePathInProjectDir];
 
             _lastCodeState[sendLog.ProjectId][newFilePathInProjectDir] = hash;
             _lastCodeState[sendLog.ProjectId].Remove(oldFilePathInProjectDir);
         }
-        catch (Exception ex)
+        catch
         {
-            // ignored
-            // TODO Handled in a different ticket; maybe send entire codebase to be sure?
+            return OnFailedDictionaryAction(sendLog, receivedRequest.ProjectDirectory);
         }
 
         return sendLog;

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -137,9 +137,11 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     {
         // TODO PatternPal only supports running the recognizer on a single project, so the projectID should be set as well.
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtXRecognizerRun;
         sendLog.RecognizerResult = receivedRequest.RecognizerResult;
         sendLog.RecognizerConfig = receivedRequest.RecognizerConfig;
+
         return sendLog;
     }
 
@@ -166,12 +168,14 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest CompileErrorLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtCompileError;
         sendLog.CompileMessageData = receivedRequest.CompileMessageData;
         sendLog.CompileMessageType = receivedRequest.CompileMessageType;
         sendLog.CodeStateSection = receivedRequest.CodeStateSection;
         sendLog.ParentEventId = receivedRequest.ParentEventId;
         sendLog.SourceLocation = receivedRequest.SourceLocation;
+
         return sendLog;
     }
 
@@ -184,6 +188,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest FileCreateLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtFileCreate;
         sendLog.CodeStateSection = receivedRequest.CodeStateSection;
         sendLog.ProjectId = receivedRequest.ProjectId;
@@ -204,21 +209,20 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest FileDeleteLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtFileDelete;
         sendLog.CodeStateSection = receivedRequest.CodeStateSection;
         sendLog.ProjectId = receivedRequest.ProjectId;
 
+        string filePathInProjectDir = Path.GetRelativePath(receivedRequest.ProjectDirectory, sendLog.CodeStateSection);
+
         try
         {
-            string projectDirectory = Path.GetDirectoryName(sendLog.ProjectId);
-            string filePathInProjectDir = Path.GetRelativePath(projectDirectory, sendLog.CodeStateSection);
-            
             _lastCodeState[sendLog.ProjectId].Remove(filePathInProjectDir);
         }
-        catch(Exception ex)
+        catch
         {
-            // ignored
-            // TODO Handled in a different ticket; maybe send entire codebase to be sure?
+            return OnFailedDictionaryAction(sendLog, receivedRequest.ProjectDirectory);
         }
 
         return sendLog;
@@ -233,31 +237,37 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static (LogRequest request, bool discard) FileEditLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         string currentHash = HashFile(receivedRequest.FilePath);
         string relativePath = Path.GetRelativePath(receivedRequest.ProjectDirectory, receivedRequest.FilePath);
 
-        try
+        sendLog.EventType = LoggingServer.EventType.EvtFileEdit;
+        sendLog.CodeStateSection = receivedRequest.CodeStateSection;
+        sendLog.ProjectId = receivedRequest.ProjectId;
+
+        // We try to obtain the previous hash of the file to compare it to the new one;
+        // if a lookup fails, we reupload the entire codeState.
         {
-            string oldHash = _lastCodeState[receivedRequest.ProjectId][relativePath];
-            // If these hashes match, the file hasn't changed and the request may be discarded.
+            string oldHash;
+            try
+            {
+                oldHash = _lastCodeState[receivedRequest.ProjectId][relativePath];
+            }
+            catch
+            {
+                return (OnFailedDictionaryAction(sendLog, receivedRequest.ProjectDirectory), false);
+            }
+
             if (currentHash == oldHash)
             {
                 return (sendLog, true);
             }
-
-            sendLog.EventType = LoggingServer.EventType.EvtFileEdit;
-            sendLog.CodeStateSection = receivedRequest.CodeStateSection;
-            sendLog.ProjectId = receivedRequest.ProjectId;
-            sendLog.Data = ZipPath(receivedRequest.FilePath, relativePath);
-            sendLog.FullCodeState = false;
-
-            return (sendLog, false);
         }
-        catch
-        {
-            // TODO Determine proper course of action
-            return (sendLog, true);
-        }
+
+        sendLog.Data = ZipPath(receivedRequest.FilePath, relativePath);
+        sendLog.FullCodeState = false;
+
+        return (sendLog, false);
     }
 
 
@@ -306,6 +316,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest ProjectCloseLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtProjectClose;
         sendLog.ProjectId = receivedRequest.ProjectId;
 
@@ -327,6 +338,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest ProjectOpenLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtProjectOpen;
         sendLog.ProjectId = receivedRequest.ProjectId;
 
@@ -349,6 +361,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     {
         // TODO Should include ProjectID
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtDebugProgram;
         sendLog.ExecutionId = receivedRequest.ExecutionId;
         sendLog.ExecutionResult = (ExecutionResult)receivedRequest.ExecutionResult;
@@ -392,10 +405,12 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest StepByStepLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtXStepByStepStep;
         sendLog.RecognizerConfig = receivedRequest.RecognizerConfig;
         sendLog.RecognizerResult = receivedRequest.RecognizerResult;
         sendLog.ProjectId = receivedRequest.ProjectId;
+        
         return sendLog;
     }
 
@@ -414,8 +429,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     /// <returns>A ByteString of the resulting archive</returns>
     public static ByteString ZipPath(string path, string relativePath = "")
     {
-        // TODO: Protect against too large codebases.
-        // Note: Calculating dirSize in C# is not trivial; omitting this for now.
+        // Note: Calculating dirSize in C# is not trivial; we are currently not protecting against large codeBases.
 
         bool isDirectory = Directory.Exists(path);
         Byte[] bytes;
@@ -509,10 +523,30 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
 
             using MD5 md5 = MD5.Create();
             using Stream stream = entry.Open();
+
+            // The lookup on key projectID will always succeed since we created that entry a few lines above.    
             _lastCodeState[projectID][entry.FullName] = Convert.ToBase64String(md5.ComputeHash(stream));
         }
 
     }
+
+   /// <summary>
+   /// Tries to resolve a failed dictionary action (like a lookup) by reuploading the entire codeBase
+   /// and thus also repopulating the stored lastCodeState for the current project.
+   /// </summary>
+   /// <param name="sendLog">The LogRequest as populated thus far</param>
+   /// <param name="projectDirectory">Path to the project directory</param>
+   /// <returns></returns>
+    private static LogRequest OnFailedDictionaryAction(LogRequest sendLog, string projectDirectory)
+   {
+       // We explicitly remove the currently stored lastCodeState for the project.
+       _lastCodeState.Remove(sendLog.ProjectId);
+
+       sendLog.Data = ZipPath(projectDirectory);
+       sendLog.FullCodeState = true;
+
+       return sendLog;
+   }
     
     #endregion
 }

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -119,7 +119,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
             ToolInstances = receivedRequest.ToolInstances,
             ClientTimestamp =
                 DateTime.UtcNow.ToString(
-                    "yyyy-MM-dd HH:mm:ss.fff zzz"), //TODO: DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss.fff  zzz"), : Logging server cannot work with offsets yet
+                    "yyyy-MM-dd HH:mm:ss.fff zzz"),
             SessionId =
                 receivedRequest.SessionId
         };
@@ -207,6 +207,19 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
         sendLog.EventType = LoggingServer.EventType.EvtFileDelete;
         sendLog.CodeStateSection = receivedRequest.CodeStateSection;
         sendLog.ProjectId = receivedRequest.ProjectId;
+
+        try
+        {
+            string projectDirectory = Path.GetDirectoryName(sendLog.ProjectId);
+            string filePathInProjectDir = Path.GetRelativePath(projectDirectory, sendLog.CodeStateSection);
+            
+            _lastCodeState[sendLog.ProjectId].Remove(filePathInProjectDir);
+        }
+        catch(Exception ex)
+        {
+            // ignored
+            // TODO Handled in a different ticket; maybe send entire codebase to be sure?
+        }
 
         return sendLog;
     }

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -272,7 +272,27 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
         LogRequest sendLog = StandardLog(receivedRequest);
         sendLog.EventType = LoggingServer.EventType.EvtFileRename;
         sendLog.CodeStateSection = receivedRequest.CodeStateSection;
+        sendLog.OldFileName = receivedRequest.OldFileName;
         sendLog.ProjectId = receivedRequest.ProjectId;
+
+        try
+        {
+            // To rename the key that stores the hash in _lastCodeState, we obtain its value, reinsert it under the new key
+            // and delete the old entry.
+            string projectDirectory = Path.GetDirectoryName(sendLog.ProjectId);
+            string oldFilePathInProjectDir = Path.GetRelativePath(projectDirectory, sendLog.OldFileName);
+            string newFilePathInProjectDir = Path.GetRelativePath(projectDirectory, sendLog.CodeStateSection);
+
+            string hash = _lastCodeState[sendLog.ProjectId][oldFilePathInProjectDir];
+
+            _lastCodeState[sendLog.ProjectId][newFilePathInProjectDir] = hash;
+            _lastCodeState[sendLog.ProjectId].Remove(oldFilePathInProjectDir);
+        }
+        catch (Exception ex)
+        {
+            // ignored
+            // TODO Handled in a different ticket; maybe send entire codebase to be sure?
+        }
 
         return sendLog;
     }

--- a/docs/dev/stepbystep/guides/implement_an_instructionset.md
+++ b/docs/dev/stepbystep/guides/implement_an_instructionset.md
@@ -1,0 +1,203 @@
+# Implement an InstructionSet
+
+To support a design pattern in PatternPal one must implement the `IStepByStepRecognizer` interface. 
+This interface defines a `string` `Name`, a `RecognizerType` as defined in the protocol buffer and 
+a method `GenerateStepsList`, which will return the object required of the Step-By-Step module.
+
+# Efficiently add to `Recognizer` functionality
+
+In order to make effective use of existing `Recognizers` for both detecting patterns and Step-By-Step 
+it is recommended to encase the `IChecks` created in the `Recognizer's` `Create` method 
+(more on this method can be found [here](~/dev/recognizers/guides/implement_recognizer.md)) into separate methods. This way the checks can
+be declared once and can be called in both `Create` in `IRecognizer` and in `GenerateStepsList` in 
+`IStepByStepRecognizer`. The Recognizers would then inherit from both recognizer interfaces (`IRecognizer` 
+and `IStepByStepRecognizer`).
+
+## Prerequisites 
+
+First, it is of utmost importance that one has a clear idea of how much is asked of the user per step. It 
+is  preferred to make the steps small and that they are supported by the available `ICheck`s 
+(available checks can be found [here](~/dev/recognizers/design/checks.md)). Second, it is important to have an explicit instruction to 
+communicate to the user what is required to pass the step and optionally an explanation why the 
+requirement is the way it is. 
+
+### Requirement and explanation per step
+The goal is to make a step as small as possible. Defining a single class/interface, a single field, 
+or a single method is considered a step. Defining a method can be more detailed because the behaviour 
+of the method needs to be described (return types, modifiers, parameters), while defining a field is the 
+smallest step (including modifiers). Anything defined in one step should be closed in such a way that you
+don't have to go back the the method/interface/field in a later step. 
+
+The entity to be implemented (e.g. fields/methods/classes/interfaces) requires an explicit `Requirement` that
+states explicitly what needs to be implemented and what the underlying `ICheck` will test for. For example: 
+"Implement a static private field of the same type as the class". 
+
+For education purposes a `Description` of the step should be provided. It should explain why the step should
+be implemented as instructed for example: "The field is static as a way of accessing the single instance when it is created.".
+
+
+## The `IStepByStepRecognizer` interface and library requirements
+
+To support a Pattern for Step-By-Step one must add the following `using` statement to the top of 
+file and implement `IStepByStepRecognizer`:
+
+```csharp
+using static PatternPal.Core.StepByStep;
+using static PatternPal.Core.StepByStep.Resources.Instructions;
+```
+
+The result class should look something like this:
+
+```csharp
+using static PatternPal.Core.StepByStep;
+using static PatternPal.Core.StepByStep.Resources.Instructions;
+
+namespace MyStepBySteps;
+
+internal class MyStepBySteps : IStepByStepRecognizer
+{
+	public string Name => "Singleton";
+	
+	public Recognizer RecognizerType => Recognizer.Singleton;
+	
+	List< IInstruction > IStepByStepRecognizer.GenerateStepsList()
+	{
+		throw new NotImplementedException();
+	}
+}
+```
+
+## The `SimpleInstruction` object
+Everything that is required by the program to retrieve information for a step and display that to the user 
+is encased in `SimpleInstruction`s. These are the `Requirement`, `Description` and a list of `ICheck`s. An 
+example of a `SimpleInstruction` would be: 
+
+```csharp
+new SimpleInstruction(
+                "Implement a...",
+                "You have to implement it this way because...",
+                new List< ICheck >
+				{
+					Class(
+						Priority.Knockout,
+						Field(
+							Priority.Knockout,
+							"Feedback message",
+							Modifiers(
+								Priority.Knockout,
+								Modifier.Static,
+								Modifier.Private
+							),
+							Type(
+								Priority.Knockout,
+								ICheck.GetCurrentEntity
+							)
+						)
+					)
+				}
+            )
+```
+
+## Implementing the `GenerateStepsList` method
+The return type is a list of `IInstruction`s. These instructions require a `string Requirement` 
+(the previously mentioned explicit instruction), `string Description` (the previously mentioned explanation) 
+and a list of `ICheck`s that reflect the requirement of the step. 
+
+The `Requirement` and `Description` are retrieved from the resources (`.resx` files). These are to be added 
+to the `PatternPal.Core` project under the folder `StepByStep\Resources\Instructions`. For example: 
+"`SingletonInstructions.resx`". Per step a `Requirement` string and `Description` string can be added to 
+this resource.
+
+Creating an `IInstruction` should lastly be supplied with a list of `ICheck`s that need to pass in a step. 
+These can be added to a list of instruction in `GenerateStepsList`. An example would be :
+
+```csharp
+
+List< IInstruction > IStepByStepRecognizer.GenerateStepsList()
+{
+	List< IInstruction > generateStepsList = new();
+	
+	// Step 1: There is a static private field with the same type as the class
+	generateStepsList.Add(
+            new SimpleInstruction(
+                SingletonInstructions.Step1,
+                SingletonInstructions.Explanation1,
+                new List< ICheck >
+				{
+					Class(
+						Priority.Knockout,
+						Field(
+							Priority.Knockout,
+							"Has a static, private field with the same type as the class",
+							Modifiers(
+								Priority.Knockout,
+								Modifier.Static,
+								Modifier.Private
+							),
+							Type(
+								Priority.Knockout,
+								ICheck.GetCurrentEntity
+							)
+						)
+					)
+				}
+            ));
+	
+	// Step 2: ...
+	...
+	
+	return generateStepsList;
+}
+```
+
+When the `IStepByStepRecognizer` interface is implemented it is automatically added as an option to the 
+extension. It can then be selected from the combobox in the `StepByStepListView`.
+
+## Final Code
+
+```csharp
+using static PatternPal.Core.StepByStep;
+using static PatternPal.Core.StepByStep.Resources.Instructions;
+
+namespace MyStepBySteps;
+
+internal class MyStepBySteps : IStepByStepRecognizer
+{
+	public string Name => "Singleton";
+	
+	public Recognizer RecognizerType => Recognizer.Singleton;
+	
+	List< IInstruction > IStepByStepRecognizer.GenerateStepsList()
+	{
+		List< IInstruction > generateStepsList = new();
+		
+		// Step 1: There is a static private field with the same type as the class
+		generateStepsList.Add(
+				new SimpleInstruction(
+					SingletonInstructions.Step1,
+					SingletonInstructions.Explanation1,
+					new List< ICheck >
+					{
+						Class(
+							Priority.Knockout,
+							Field(
+								Priority.Knockout,
+								"Has a static, private field with the same type as the class",
+								Modifiers(
+									Priority.Knockout,
+									Modifier.Static,
+									Modifier.Private
+								),
+								Type(
+									Priority.Knockout,
+									ICheck.GetCurrentEntity
+								)
+							)
+						)
+					}
+				));
+		
+		return generateStepsList;
+	}
+}
+```

--- a/docs/dev/toc.yml
+++ b/docs/dev/toc.yml
@@ -29,6 +29,8 @@
     href: recognizers/guides/implement_recognizer.md
   - name: Implementing a Check
     href: recognizers/guides/implement_check.md
+  - name: Adding a design pattern to Step-By-Step
+    href: stepbystep/guides/implement_an_instructionset.md
 
 # Pattern recognition --------------------
 - name: Data logging


### PR DESCRIPTION
- No codestate is actually generated server-side since we can trace the
renamed file in the database and use that data when restoring the
eventual codestates.
- On a `File.Rename`-event, the respective entry in the local hashed
codestate is deleted and reinserted under the new name.

Currently, the `FileWatcher` does not detect renaming the parent directory of a
`*.cs`-file. Marked that as a bug
for future fix.

@JustNireon; for testing, please reupdate the PostgreSQL-definitions because a new field has been added to the database.