### PR TITLE
Log: Implemented dict exception handling

### DIFF
--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -193,6 +193,7 @@ namespace PatternPal.Extension.Commands
                 $"Build {action.ToString()} succeeded.";
 
             LogEventRequest request = CreateStandardLog();
+
             string pathSolutionFullName = _dte.Solution.FullName;
             string pathSolutionFile = _dte.Solution.FileName;
 
@@ -254,13 +255,16 @@ namespace PatternPal.Extension.Commands
             }
 
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtFileCreate;
             request.CodeStateSection = fileSystemEventArgs.Name;
+
             string projectFullPath = FindContainingCsprojFile(fileSystemEventArgs.FullPath);
             string projectDirectory = Path.GetDirectoryName(projectFullPath);
             request.ProjectId = GetRelativePath(projectDirectory, projectFullPath);
             request.ProjectDirectory = Path.GetDirectoryName(projectFullPath);
-            request.ProjectId = GetRelativePath(request.ProjectDirectory, projectFullPath);
+            request.ProjectId = GetRelativePath(projectDirectory, projectFullPath);
+
             request.FilePath = fileSystemEventArgs.FullPath;
             
             LogEventResponse response = PushLog(request);
@@ -289,10 +293,13 @@ namespace PatternPal.Extension.Commands
             }
 
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtFileDelete;
             request.CodeStateSection = fileSystemEventArgs.Name;
+
             string projectFullPath = FindContainingCsprojFile(fileSystemEventArgs.FullPath);
             string projectDirectory = Path.GetDirectoryName(projectFullPath);
+            request.ProjectDirectory = projectDirectory;
             request.ProjectId = GetRelativePath(projectDirectory, projectFullPath);
 
             LogEventResponse response = PushLog(request);
@@ -312,13 +319,15 @@ namespace PatternPal.Extension.Commands
             }
 
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtFileRename;
             request.CodeStateSection = e.Name;
             request.OldFileName = e.OldName;
 
             string projectFullPath = FindContainingCsprojFile(e.FullPath);
-            string projectFolderName = Path.GetDirectoryName(projectFullPath);
-            request.ProjectId = GetRelativePath(projectFolderName, projectFullPath);
+            string projectDirectory = Path.GetDirectoryName(projectFullPath);
+            request.ProjectDirectory = projectDirectory;
+            request.ProjectId = GetRelativePath(projectDirectory, projectFullPath);
 
             LogEventResponse response = PushLog(request);
         }
@@ -358,6 +367,7 @@ namespace PatternPal.Extension.Commands
             string sourceLocation, string codeStateSection)
         {
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtCompileError;
             request.ParentEventId = parent.EventId;
             request.CompileMessageType = compileMessagetype;
@@ -396,6 +406,7 @@ namespace PatternPal.Extension.Commands
         private static void OnDebugProgram(dbgEventReason reason)
         {
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtDebugProgram;
             request.ExecutionId = Guid.NewGuid().ToString();
 
@@ -423,8 +434,8 @@ namespace PatternPal.Extension.Commands
             ThreadHelper.ThrowIfNotOnUIThread();
 
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtFileEdit;
-            
             request.CodeStateSection = GetRelativePath(Path.GetDirectoryName(document.FullName), document.FullName);
             request.ProjectId = document.ProjectItem.ContainingProject.UniqueName;
             request.ProjectDirectory = Path.GetDirectoryName(document.ProjectItem.ContainingProject.FullName);
@@ -446,6 +457,7 @@ namespace PatternPal.Extension.Commands
             }
             
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtXRecognizerRun;
             string config = recognizeRequest.Recognizers.ToString();
 
@@ -472,6 +484,7 @@ namespace PatternPal.Extension.Commands
                 return;
             }
             LogEventRequest request = CreateStandardLog();
+
             request.EventType = EventType.EvtXStepByStepStep;
             // config should be dict with recognizer name and current instruction number
             Dictionary<string,string> config = new Dictionary<string, string>()

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -137,9 +137,11 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     {
         // TODO PatternPal only supports running the recognizer on a single project, so the projectID should be set as well.
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtXRecognizerRun;
         sendLog.RecognizerResult = receivedRequest.RecognizerResult;
         sendLog.RecognizerConfig = receivedRequest.RecognizerConfig;
+
         return sendLog;
     }
 
@@ -166,12 +168,14 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest CompileErrorLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtCompileError;
         sendLog.CompileMessageData = receivedRequest.CompileMessageData;
         sendLog.CompileMessageType = receivedRequest.CompileMessageType;
         sendLog.CodeStateSection = receivedRequest.CodeStateSection;
         sendLog.ParentEventId = receivedRequest.ParentEventId;
         sendLog.SourceLocation = receivedRequest.SourceLocation;
+
         return sendLog;
     }
 
@@ -184,6 +188,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest FileCreateLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtFileCreate;
         sendLog.CodeStateSection = receivedRequest.CodeStateSection;
         sendLog.ProjectId = receivedRequest.ProjectId;
@@ -204,21 +209,20 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest FileDeleteLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtFileDelete;
         sendLog.CodeStateSection = receivedRequest.CodeStateSection;
         sendLog.ProjectId = receivedRequest.ProjectId;
 
+        string filePathInProjectDir = Path.GetRelativePath(receivedRequest.ProjectDirectory, sendLog.CodeStateSection);
+
         try
         {
-            string projectDirectory = Path.GetDirectoryName(sendLog.ProjectId);
-            string filePathInProjectDir = Path.GetRelativePath(projectDirectory, sendLog.CodeStateSection);
-            
             _lastCodeState[sendLog.ProjectId].Remove(filePathInProjectDir);
         }
-        catch(Exception ex)
+        catch
         {
-            // ignored
-            // TODO Handled in a different ticket; maybe send entire codebase to be sure?
+            return OnFailedDictionaryAction(sendLog, receivedRequest.ProjectDirectory);
         }
 
         return sendLog;
@@ -233,31 +237,37 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static (LogRequest request, bool discard) FileEditLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         string currentHash = HashFile(receivedRequest.FilePath);
         string relativePath = Path.GetRelativePath(receivedRequest.ProjectDirectory, receivedRequest.FilePath);
 
-        try
+        sendLog.EventType = LoggingServer.EventType.EvtFileEdit;
+        sendLog.CodeStateSection = receivedRequest.CodeStateSection;
+        sendLog.ProjectId = receivedRequest.ProjectId;
+
+        // We try to obtain the previous hash of the file to compare it to the new one;
+        // if a lookup fails, we reupload the entire codeState.
         {
-            string oldHash = _lastCodeState[receivedRequest.ProjectId][relativePath];
-            // If these hashes match, the file hasn't changed and the request may be discarded.
+            string oldHash;
+            try
+            {
+                oldHash = _lastCodeState[receivedRequest.ProjectId][relativePath];
+            }
+            catch
+            {
+                return (OnFailedDictionaryAction(sendLog, receivedRequest.ProjectDirectory), false);
+            }
+
             if (currentHash == oldHash)
             {
                 return (sendLog, true);
             }
-
-            sendLog.EventType = LoggingServer.EventType.EvtFileEdit;
-            sendLog.CodeStateSection = receivedRequest.CodeStateSection;
-            sendLog.ProjectId = receivedRequest.ProjectId;
-            sendLog.Data = ZipPath(receivedRequest.FilePath, relativePath);
-            sendLog.FullCodeState = false;
-
-            return (sendLog, false);
         }
-        catch
-        {
-            // TODO Determine proper course of action
-            return (sendLog, true);
-        }
+
+        sendLog.Data = ZipPath(receivedRequest.FilePath, relativePath);
+        sendLog.FullCodeState = false;
+
+        return (sendLog, false);
     }
 
 
@@ -286,6 +296,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest ProjectCloseLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtProjectClose;
         sendLog.ProjectId = receivedRequest.ProjectId;
 
@@ -307,6 +318,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest ProjectOpenLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtProjectOpen;
         sendLog.ProjectId = receivedRequest.ProjectId;
 
@@ -329,6 +341,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     {
         // TODO Should include ProjectID
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtDebugProgram;
         sendLog.ExecutionId = receivedRequest.ExecutionId;
         sendLog.ExecutionResult = (ExecutionResult)receivedRequest.ExecutionResult;
@@ -372,10 +385,12 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest StepByStepLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtXStepByStepStep;
         sendLog.RecognizerConfig = receivedRequest.RecognizerConfig;
         sendLog.RecognizerResult = receivedRequest.RecognizerResult;
         sendLog.ProjectId = receivedRequest.ProjectId;
+        
         return sendLog;
     }
 
@@ -394,8 +409,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     /// <returns>A ByteString of the resulting archive</returns>
     public static ByteString ZipPath(string path, string relativePath = "")
     {
-        // TODO: Protect against too large codebases.
-        // Note: Calculating dirSize in C# is not trivial; omitting this for now.
+        // Note: Calculating dirSize in C# is not trivial; we are currently not protecting against large codeBases.
 
         bool isDirectory = Directory.Exists(path);
         Byte[] bytes;
@@ -489,10 +503,30 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
 
             using MD5 md5 = MD5.Create();
             using Stream stream = entry.Open();
+
+            // The lookup on key projectID will always succeed since we created that entry a few lines above.    
             _lastCodeState[projectID][entry.FullName] = Convert.ToBase64String(md5.ComputeHash(stream));
         }
 
     }
+
+   /// <summary>
+   /// Tries to resolve a failed dictionary action (like a lookup) by reuploading the entire codeBase
+   /// and thus also repopulating the stored lastCodeState for the current project.
+   /// </summary>
+   /// <param name="sendLog">The LogRequest as populated thus far</param>
+   /// <param name="projectDirectory">Path to the project directory</param>
+   /// <returns></returns>
+    private static LogRequest OnFailedDictionaryAction(LogRequest sendLog, string projectDirectory)
+   {
+       // We explicitly remove the currently stored lastCodeState for the project.
+       _lastCodeState.Remove(sendLog.ProjectId);
+
+       sendLog.Data = ZipPath(projectDirectory);
+       sendLog.FullCodeState = true;
+
+       return sendLog;
+   }
     
     #endregion
 }


### PR DESCRIPTION
- An unsuccessful lookup in the `_lastCodeState`-dictionary will now lead to a repeated push of the entire codeBase to the server, thus also repopulating the `_lastCodeState` for that specific project.
- Added some whitelines for consistency and improved readability.