### PR TITLE
Log: Factored out `DateTimeOffset` in favour of `DateTime`

### DIFF
--- a/PatternPal/PatternPal.LoggingServer/Migrations/20230622094043_ChangeDateTimeoffsetToNormal.Designer.cs
+++ b/PatternPal/PatternPal.LoggingServer/Migrations/20230622094043_ChangeDateTimeoffsetToNormal.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PatternPal.LoggingServer.Data;
@@ -11,9 +12,11 @@ using PatternPal.LoggingServer.Data;
 namespace PatternPal.LoggingServer.Migrations
 {
     [DbContext(typeof(ProgSnap2ContextClass))]
-    partial class ProgSnap2ContextClassModelSnapshot : ModelSnapshot
+    [Migration("20230622094043_ChangeDateTimeoffsetToNormal")]
+    partial class ChangeDateTimeoffsetToNormal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/PatternPal/PatternPal.LoggingServer/Migrations/20230622094043_ChangeDateTimeoffsetToNormal.cs
+++ b/PatternPal/PatternPal.LoggingServer/Migrations/20230622094043_ChangeDateTimeoffsetToNormal.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatternPal.LoggingServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeDateTimeoffsetToNormal : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/PatternPal/PatternPal.LoggingServer/Models/ProgSnap2.cs
+++ b/PatternPal/PatternPal.LoggingServer/Models/ProgSnap2.cs
@@ -57,12 +57,12 @@ namespace PatternPal.LoggingServer.Models
         /// <summary>
         /// The date and time of the event, in the server's time zone.
         /// </summary>
-        public DateTimeOffset ServerDatetime { get; set; }
+        public DateTime ServerDatetime { get; set; }
 
         /// <summary>
         /// The date and time of the event, in the client's time zone.
         /// </summary>
-        public DateTimeOffset ClientDatetime { get; set; }
+        public DateTime ClientDatetime { get; set; }
 
         /// <summary>
         /// The ID of the parent event, if any. Used in cases such as compile.error, where the parent event is compile.

--- a/PatternPal/PatternPal.LoggingServer/Services/LoggerService.cs
+++ b/PatternPal/PatternPal.LoggingServer/Services/LoggerService.cs
@@ -95,7 +95,7 @@ namespace PatternPal.LoggingServer.Services
                 OldFileName = request.HasOldFileName ? request.OldFileName : null,
                 FullCodeState = request.HasFullCodeState ? request.FullCodeState : null,
                 ClientDatetime = clientDateTime,
-                ServerDatetime = DateTime.UtcNow,
+                ServerDatetime = DateTime.Now,
                 SessionId = sessionId,
                 ProjectId = request.HasProjectId ? request.ProjectId : null,
                 ParentId = parentEventId,

--- a/PatternPal/PatternPal.LoggingServer/Services/LoggerService.cs
+++ b/PatternPal/PatternPal.LoggingServer/Services/LoggerService.cs
@@ -64,7 +64,7 @@ namespace PatternPal.LoggingServer.Services
                 }
             }
 
-            if (!DateTimeOffset.TryParse(request.ClientTimestamp, out DateTimeOffset cDto))
+            if (!DateTime.TryParse(request.ClientTimestamp, out DateTime clientDateTime))
             {
                 return await Task.FromResult(new LogResponse
                 {
@@ -94,8 +94,8 @@ namespace PatternPal.LoggingServer.Services
                 CodeStateId = codeStateId,
                 OldFileName = request.HasOldFileName ? request.OldFileName : null,
                 FullCodeState = request.HasFullCodeState ? request.FullCodeState : null,
-                ClientDatetime = cDto,
-                ServerDatetime = DateTimeOffset.Now,
+                ClientDatetime = clientDateTime,
+                ServerDatetime = DateTime.Now,
                 SessionId = sessionId,
                 ProjectId = request.HasProjectId ? request.ProjectId : null,
                 ParentId = parentEventId,

--- a/PatternPal/PatternPal.LoggingServer/Services/LoggerService.cs
+++ b/PatternPal/PatternPal.LoggingServer/Services/LoggerService.cs
@@ -95,7 +95,7 @@ namespace PatternPal.LoggingServer.Services
                 OldFileName = request.HasOldFileName ? request.OldFileName : null,
                 FullCodeState = request.HasFullCodeState ? request.FullCodeState : null,
                 ClientDatetime = clientDateTime,
-                ServerDatetime = DateTime.Now,
+                ServerDatetime = DateTime.UtcNow,
                 SessionId = sessionId,
                 ProjectId = request.HasProjectId ? request.ProjectId : null,
                 ParentId = parentEventId,

--- a/PatternPal/PatternPal.LoggingServerTests/LoggingTests.cs
+++ b/PatternPal/PatternPal.LoggingServerTests/LoggingTests.cs
@@ -1,5 +1,6 @@
 ﻿#region
 
+using System.Globalization;
 using System.IO.Compression;
 using Google.Protobuf;
 using Grpc.Core;
@@ -60,7 +61,7 @@ namespace PatternPal.LoggingServerTests
                 SessionId = Guid.NewGuid().ToString(),
                 SubjectId = Guid.NewGuid().ToString(),
                 EventType = EventType.EvtSessionStart,
-                ClientTimestamp = DateTimeOffset.Now.ToString("o"),
+                ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"),
                 ProjectId = "TestProject",
             };
 
@@ -108,7 +109,7 @@ namespace PatternPal.LoggingServerTests
                 SessionId = "invalid session ID",
                 SubjectId = Guid.NewGuid().ToString(),
                 EventType = EventType.EvtProjectOpen,
-                ClientTimestamp = DateTimeOffset.Now.ToString("o"),
+                ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"),
                 ProjectId = "TestProject",
                 Data = ByteString.CopyFrom(new byte[] { 1, 2, 3 })
             };
@@ -130,7 +131,7 @@ namespace PatternPal.LoggingServerTests
                 SessionId = Guid.NewGuid().ToString(),
                 SubjectId = Guid.NewGuid().ToString(),
                 EventType = EventType.EvtUnknown,
-                ClientTimestamp = DateTimeOffset.Now.ToString("o"),
+                ClientTimestamp = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture),
                 ProjectId = "TestProject",
                 Data = ByteString.CopyFrom(new byte[] { 1, 2, 3 })
             };
@@ -150,7 +151,7 @@ namespace PatternPal.LoggingServerTests
                 SessionId = Guid.NewGuid().ToString(),
                 SubjectId = Guid.NewGuid().ToString(),
                 EventType = EventType.EvtProjectClose,
-                ClientTimestamp = DateTimeOffset.Now.ToString("o"),
+                ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"),
                 ProjectId = "TestProject",
                 Data = ByteString.CopyFrom(CreateZipArchive(filenameCs))
             };

--- a/PatternPal/PatternPal.LoggingServerTests/LoggingTests.cs
+++ b/PatternPal/PatternPal.LoggingServerTests/LoggingTests.cs
@@ -61,7 +61,7 @@ namespace PatternPal.LoggingServerTests
                 SessionId = Guid.NewGuid().ToString(),
                 SubjectId = Guid.NewGuid().ToString(),
                 EventType = EventType.EvtSessionStart,
-                ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"),
+                ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff"),
                 ProjectId = "TestProject",
             };
 
@@ -109,7 +109,7 @@ namespace PatternPal.LoggingServerTests
                 SessionId = "invalid session ID",
                 SubjectId = Guid.NewGuid().ToString(),
                 EventType = EventType.EvtProjectOpen,
-                ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"),
+                ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff"),
                 ProjectId = "TestProject",
                 Data = ByteString.CopyFrom(new byte[] { 1, 2, 3 })
             };
@@ -131,7 +131,7 @@ namespace PatternPal.LoggingServerTests
                 SessionId = Guid.NewGuid().ToString(),
                 SubjectId = Guid.NewGuid().ToString(),
                 EventType = EventType.EvtUnknown,
-                ClientTimestamp = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture),
+                ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff"),
                 ProjectId = "TestProject",
                 Data = ByteString.CopyFrom(new byte[] { 1, 2, 3 })
             };
@@ -151,7 +151,7 @@ namespace PatternPal.LoggingServerTests
                 SessionId = Guid.NewGuid().ToString(),
                 SubjectId = Guid.NewGuid().ToString(),
                 EventType = EventType.EvtProjectClose,
-                ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"),
+                ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff"),
                 ProjectId = "TestProject",
                 Data = ByteString.CopyFrom(CreateZipArchive(filenameCs))
             };

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -1,4 +1,4 @@
-﻿#region
+#region
 
 using Google.Protobuf;
 using System.IO.Compression;
@@ -117,7 +117,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
             EventId = receivedRequest.EventId,
             SubjectId = receivedRequest.SubjectId,
             ToolInstances = receivedRequest.ToolInstances,
-            ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"),
+            ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff"),
             SessionId =
                 receivedRequest.SessionId
         };

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -117,9 +117,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
             EventId = receivedRequest.EventId,
             SubjectId = receivedRequest.SubjectId,
             ToolInstances = receivedRequest.ToolInstances,
-            ClientTimestamp =
-                DateTime.UtcNow.ToString(
-                    "yyyy-MM-dd HH:mm:ss.fff"),
+            ClientTimestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"),
             SessionId =
                 receivedRequest.SessionId
         };

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -119,7 +119,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
             ToolInstances = receivedRequest.ToolInstances,
             ClientTimestamp =
                 DateTime.UtcNow.ToString(
-                    "yyyy-MM-dd HH:mm:ss.fff zzz"),
+                    "yyyy-MM-dd HH:mm:ss.fff"),
             SessionId =
                 receivedRequest.SessionId
         };


### PR DESCRIPTION
- Amended `PatternPal`, `PatternPal.LoggingServer` and `PatternPal.LoggingServerTests`
- `DateTime`s are now stored in `UTC` everywhere; since we are also always querying in that format that should not be too bad since we at least have a specific format to adhere to now. Client should simply be aware of this.