### PR TITLE
Log: Fixed CodeStateSection for `File.Edit`

### DIFF
--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -436,9 +436,9 @@ namespace PatternPal.Extension.Commands
             LogEventRequest request = CreateStandardLog();
 
             request.EventType = EventType.EvtFileEdit;
-            request.CodeStateSection = GetRelativePath(Path.GetDirectoryName(document.FullName), document.FullName);
             request.ProjectId = document.ProjectItem.ContainingProject.UniqueName;
             request.ProjectDirectory = Path.GetDirectoryName(document.ProjectItem.ContainingProject.FullName);
+            request.CodeStateSection = GetRelativePath(request.ProjectDirectory, document.FullName);
             request.FilePath = document.FullName;
 
             LogEventResponse response = PushLog(request);


### PR DESCRIPTION
The CodeStateSection for `File.Edit` would only include the direct parent directory (unlike other events); that is now fixed.