### PR TITLE
Log: Fixed wrong dict-lookups for `File.Rename` and `File.Delete`

### DIFF
--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -1,4 +1,4 @@
-#region
+﻿#region
 
 using Google.Protobuf;
 using System.IO.Compression;
@@ -212,7 +212,8 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
         sendLog.CodeStateSection = receivedRequest.CodeStateSection;
         sendLog.ProjectId = receivedRequest.ProjectId;
 
-        string filePathInProjectDir = Path.GetRelativePath(receivedRequest.ProjectDirectory, sendLog.CodeStateSection);
+        // The included path is only relative to the direct parent directory of the .csproj-file.
+        string filePathInProjectDir = Path.GetRelativePath(Path.GetDirectoryName(sendLog.ProjectId)!, sendLog.CodeStateSection);
 
         try
         {
@@ -283,8 +284,8 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
         sendLog.OldFileName = receivedRequest.OldFileName;
         sendLog.ProjectId = receivedRequest.ProjectId;
 
-        string oldFilePathInProjectDir = Path.GetRelativePath(receivedRequest.ProjectDirectory, sendLog.OldFileName);
-        string newFilePathInProjectDir = Path.GetRelativePath(receivedRequest.ProjectDirectory, sendLog.CodeStateSection);
+        string oldFilePathInProjectDir = Path.GetRelativePath(Path.GetDirectoryName(sendLog.ProjectId)!, sendLog.OldFileName);
+        string newFilePathInProjectDir = Path.GetRelativePath(Path.GetDirectoryName(sendLog.ProjectId)!, sendLog.CodeStateSection);
         try
         {
             // To rename the key that stores the hash in _lastCodeState, we obtain its value, reinsert it under the new key
@@ -294,7 +295,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
             _lastCodeState[sendLog.ProjectId][newFilePathInProjectDir] = hash;
             _lastCodeState[sendLog.ProjectId].Remove(oldFilePathInProjectDir);
         }
-        catch
+        catch (Exception e)
         {
             return OnFailedDictionaryAction(sendLog, receivedRequest.ProjectDirectory);
         }


### PR DESCRIPTION
The relative directory lookup was based on a full path, while it was trying to find a relative match against the project path only. That is now fixed.