### PR TITLE
Log: Included `ProjectId` as a logged field in extra events

### DIFF
--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -547,7 +547,7 @@ namespace PatternPal.Extension.Commands
 
             request.RecognizerResult = JsonSerializer.Serialize(results);
             
-            Project project = _dte.ActiveDocument.ProjectItem.ContainingProject;
+            Project project = _dte.ActiveDocument?.ProjectItem?.ContainingProject;
             request.ProjectId = project.UniqueName;
 
             LogEventResponse response = PushLog(request);

--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -488,6 +488,10 @@ namespace PatternPal.Extension.Commands
                     if (projectItem?.ContainingProject?.UniqueName != null)
                     {
                         request.ProjectId = projectItem.ContainingProject.UniqueName;
+                        string fileDir = Path.GetDirectoryName(recognizeRequest.File);
+
+                        // Since the recognizer is only run on a single file, we also include a codeState.
+                        request.CodeStateSection = GetRelativePath(fileDir, recognizeRequest.File);
                     };
 
                 }

--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -425,6 +425,20 @@ namespace PatternPal.Extension.Commands
             request.EventType = EventType.EvtDebugProgram;
             request.ExecutionId = Guid.NewGuid().ToString();
 
+            try
+            {
+                // The project that was actually debugged is simply assumed to be the first
+                // startup project here; that seems fine for the scope for PatternPal.
+                Array startupProjects = (Array)_dte.Solution?.SolutionBuild?.StartupProjects;
+                request.ProjectId = (string)startupProjects?.GetValue(0);
+            }
+
+            catch
+            {
+                // Ignored, we simply do not include a projectID
+            }
+            
+
             if (_unhandledExceptionThrown)
             {
                 request.ExecutionResult = ExecutionResult.ExtError;

--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -185,6 +185,7 @@ namespace PatternPal.Extension.Commands
             vsBuildScope scope,
             vsBuildAction action)
         {
+            // TODO This method needs major refactoring and error handling
             if (action == vsBuildAction.vsBuildActionClean)
             {
                 return;
@@ -199,7 +200,7 @@ namespace PatternPal.Extension.Commands
 
             string pathSolutionFullName = _dte.Solution.FullName;
             string pathSolutionFile = _dte.Solution.FileName;
-
+        
             // Distinguish a sln file or just a csproj file to be opened
             if (pathSolutionFullName == "")
             {
@@ -212,6 +213,16 @@ namespace PatternPal.Extension.Commands
             {
                 string pathSolutionDirectory = Path.GetDirectoryName(pathSolutionFullName);
                 request.CodeStateSection = GetRelativePath(pathSolutionDirectory, pathSolutionFile);
+            }
+
+            if(scope == vsBuildScope.vsBuildScopeProject)
+            {
+                // If the build scope was a project and not the entire solution, we know for
+                // sure that a start-up project has been specified and thus we can say something useful
+                // about the projectId. We chose to only store the first one because building multiple
+                // projects seems out of the scope of PatternPal and ProgSnap2.
+                Array startupProjects = (Array)_dte.Solution.SolutionBuild.StartupProjects;
+                request.ProjectId = (string)startupProjects.GetValue(0);
             }
 
             request.EventType = EventType.EvtCompile;
@@ -377,6 +388,7 @@ namespace PatternPal.Extension.Commands
             request.CompileMessageData = compileMessageData;
             request.SourceLocation = sourceLocation;
             request.CodeStateSection = codeStateSection;
+            request.ProjectId = parent.ProjectId;
 
             LogEventResponse response = PushLog(request);
         }

--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -4,17 +4,19 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+
 using EnvDTE;
 using EnvDTE80;
+
 using Microsoft.VisualStudio.Shell;
+
 using PatternPal.Extension.Grpc;
 using PatternPal.Protos;
-using System.Text.RegularExpressions;
+
 using JsonSerializer = System.Text.Json.JsonSerializer;
-using Google.Protobuf.Collections;
 
 #endregion
 
@@ -98,6 +100,7 @@ namespace PatternPal.Extension.Commands
             _package = package;
             _cancellationToken = cancellationToken;
             _toolInstances = $" { _dte.Version } { _dte.Edition } { _dte.Name } {Vsix.Version}";
+
             // We should call OnChangedLoggingPreference to "load" a possibly stored setting. The
             // application always stored with the internal flag set to false, so this will only actually
             // do something when it was stored as true (and subsequently kickstart the logging session).
@@ -592,14 +595,9 @@ namespace PatternPal.Extension.Commands
 
             foreach (Project project in projects)
             {
-                if (project == null)
-                {
-                    continue;
-                }
-
                 // This catches miscellaneous projects without a defined project.Fullname; the cause of this is unknown since
                 // we are using internal-use-only libraries for event catching.
-                if (project.FullName == null || !File.Exists((project.FullName)))
+                if (project?.FullName == null || !File.Exists((project.FullName)))
                 {
                     continue;
                 }

--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -481,7 +481,7 @@ namespace PatternPal.Extension.Commands
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            if (_package == null || !Privacy.Instance.DoLogData 
+            if (_package == null || !_doLog 
                                  || recognizeRequest.FileOrProjectCase == RecognizeRequest.FileOrProjectOneofCase.None)
             { 
               return; 

--- a/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
+++ b/PatternPal/PatternPal.Extension/Commands/SubscribeEvents.cs
@@ -466,6 +466,7 @@ namespace PatternPal.Extension.Commands
             IList<RecognizeResult> recognizeResults)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
+
             if (_package == null || !Privacy.Instance.DoLogData)
             { 
               return; 
@@ -474,7 +475,28 @@ namespace PatternPal.Extension.Commands
             LogEventRequest request = CreateStandardLog();
 
             request.EventType = EventType.EvtXRecognizerRun;
+
+            if (recognizeRequest.FileOrProjectCase == RecognizeRequest.FileOrProjectOneofCase.File)
+            {
+                // The extension either runs on the currently active document or an entire project.
+                // In case of the current active document, we try obtaining the projectID using eventDTE.
+                if (_dte.SelectedItems.Count > 0)
+                {
+                    SelectedItem selectedItem = _dte.SelectedItems.Item(0);
+                    if (selectedItem.Project != null)
+                    {
+                        request.ProjectId = selectedItem.Project.UniqueName;
+                    }
+
+                }
+            }
+            else
+            {
+                
+            }
+
             string config = recognizeRequest.Recognizers.ToString();
+
 
             request.RecognizerConfig = config;
             foreach (RecognizeResult result in recognizeResults)

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -360,12 +360,12 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     /// <returns>A LogRequest populated for this specific event</returns>
     private static LogRequest DebugProgramLog(LogEventRequest receivedRequest)
     {
-        // TODO Should include ProjectID
         LogRequest sendLog = StandardLog(receivedRequest);
 
         sendLog.EventType = LoggingServer.EventType.EvtDebugProgram;
         sendLog.ExecutionId = receivedRequest.ExecutionId;
         sendLog.ExecutionResult = (ExecutionResult)receivedRequest.ExecutionResult;
+        sendLog.ProjectId = receivedRequest.ProjectId;
 
         return sendLog;
     }

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -152,8 +152,11 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     private static LogRequest CompileLog(LogEventRequest receivedRequest)
     {
         LogRequest sendLog = StandardLog(receivedRequest);
+
         sendLog.EventType = LoggingServer.EventType.EvtCompile;
         sendLog.CompileResult = receivedRequest.CompileResult;
+        sendLog.ProjectId = receivedRequest.ProjectId;
+
         return sendLog;
     }
 
@@ -173,6 +176,7 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
         sendLog.CodeStateSection = receivedRequest.CodeStateSection;
         sendLog.ParentEventId = receivedRequest.ParentEventId;
         sendLog.SourceLocation = receivedRequest.SourceLocation;
+        sendLog.ProjectId = receivedRequest.ProjectId;
 
         return sendLog;
     }

--- a/PatternPal/PatternPal/Services/LoggingService.cs
+++ b/PatternPal/PatternPal/Services/LoggingService.cs
@@ -133,9 +133,10 @@ public class LoggingService : LogProviderService.LogProviderServiceBase
     /// <returns>A LogRequest populated for this specific event</returns>
     private static LogRequest RecognizeLog(LogEventRequest receivedRequest)
     {
-        // TODO PatternPal only supports running the recognizer on a single project, so the projectID should be set as well.
         LogRequest sendLog = StandardLog(receivedRequest);
 
+        sendLog.CodeStateSection = receivedRequest.CodeStateSection;
+        sendLog.ProjectId = receivedRequest.ProjectId;
         sendLog.EventType = LoggingServer.EventType.EvtXRecognizerRun;
         sendLog.RecognizerResult = receivedRequest.RecognizerResult;
         sendLog.RecognizerConfig = receivedRequest.RecognizerConfig;


### PR DESCRIPTION
Now also including `ProjectId` for:
- `EvtCompile`
- `EvtCompileError`
- `EvtDebugProgram`
- `EvtXRecognizerRun`

Also caught some bugs in:
- `EvtXRecognizerRun`
- `EvtXStepByStep`