### PR TITLE
Console: Set single file publish

### DIFF
--- a/PatternPal/PatternPal.Console/PatternPal.ConsoleApp.csproj
+++ b/PatternPal/PatternPal.Console/PatternPal.ConsoleApp.csproj
@@ -5,6 +5,9 @@
     <OutputType>Exe</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup>
+    <PublishSingleFile>True</PublishSingleFile>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\PatternPal.Core\PatternPal.Core.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This allows using the following command to create a self-contained (i.e. installing `.NET` is not required) executable:
```sh
# In PatternPal/PatternPal.Console/
dotnet publish --self-contained --configuration Release --output .
```