### PR TITLE
SBS: Fixed the repeating instruction in the SBS instructions view

### DIFF
--- a/PatternPal/PatternPal.Extension/ViewModels/StepByStepInstructionsViewModel.cs
+++ b/PatternPal/PatternPal.Extension/ViewModels/StepByStepInstructionsViewModel.cs
@@ -86,6 +86,8 @@ namespace PatternPal.Extension.ViewModels
             }
 
             CurrentInstructionNumber++;
+            // If the current instruction number is higher than the number of instructions so far
+            // then see if there is already an entry otherwise add.
             if (_currentInstructionNumber >= _instructions.Count)
             {
                 try

--- a/PatternPal/PatternPal.Extension/ViewModels/StepByStepInstructionsViewModel.cs
+++ b/PatternPal/PatternPal.Extension/ViewModels/StepByStepInstructionsViewModel.cs
@@ -17,7 +17,7 @@ namespace PatternPal.Extension.ViewModels
     /// </summary>
     public class StepByStepInstructionsViewModel : ViewModel
     {
-        private readonly IList< Instruction > _instructions;
+        private readonly Instruction[] _instructions;
         private readonly InstructionSet _instructionSet;
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace PatternPal.Extension.ViewModels
         /// <summary>
         /// Files to check for each step.
         /// </summary>
-        public List< string > FilePaths { get; set; }
+        public List<string> FilePaths { get; set; }
 
         /// <summary>
         /// The mode in which Step by Step operates.
@@ -43,7 +43,7 @@ namespace PatternPal.Extension.ViewModels
         /// <summary>
         /// The current <see cref="Instruction"/>.
         /// </summary>
-        public Instruction CurrentInstruction => _instructions[ _currentInstructionNumber - 1 ];
+        public Instruction CurrentInstruction => _instructions[_currentInstructionNumber - 1];
 
         private int _currentInstructionNumber;
 
@@ -56,7 +56,7 @@ namespace PatternPal.Extension.ViewModels
             private set
             {
                 _currentInstructionNumber = value;
-                OnPropertyChanged(nameof( Title ));
+                OnPropertyChanged(nameof(Title));
             }
         }
 
@@ -71,7 +71,7 @@ namespace PatternPal.Extension.ViewModels
             }
 
             CurrentInstructionNumber--;
-            OnPropertyChanged(nameof( CurrentInstruction ));
+            OnPropertyChanged(nameof(CurrentInstruction));
             return true;
         }
 
@@ -86,23 +86,15 @@ namespace PatternPal.Extension.ViewModels
             }
 
             CurrentInstructionNumber++;
-            // If the current instruction number is higher than the number of instructions so far
-            // then see if there is already an entry otherwise add.
-            if (_currentInstructionNumber >= _instructions.Count)
+
+            if (null == _instructions[CurrentInstructionNumber - 1])
             {
-                try
-                {
-                    Instruction value = _instructions[_currentInstructionNumber-1];
-                }
-                catch
-                {
-                    _instructions.Add(
-                        GetInstructionById(
-                            CurrentInstructionNumber - 1,
-                            Recognizer));
-                }
+                _instructions[CurrentInstructionNumber - 1] = GetInstructionById(
+                    CurrentInstructionNumber,
+                    Recognizer);
             }
-            OnPropertyChanged(nameof( CurrentInstruction ));
+
+            OnPropertyChanged(nameof(CurrentInstruction));
             return true;
         }
 
@@ -132,9 +124,9 @@ namespace PatternPal.Extension.ViewModels
             NavigationStore navigationStore,
             Recognizer recognizer,
             StepByStepModes mode,
-            List< string > filePaths)
+            List<string> filePaths)
         {
-            NavigateHomeCommand = new NavigateCommand< HomeViewModel >(
+            NavigateHomeCommand = new NavigateCommand<HomeViewModel>(
                 navigationStore,
                 () => new HomeViewModel(navigationStore));
             Recognizer = recognizer;
@@ -147,13 +139,12 @@ namespace PatternPal.Extension.ViewModels
                     });
             _instructionSet = instructionSetResponse.SelectedInstructionset;
 
-            _instructions = new List< Instruction >((int)_instructionSet.NumberOfInstructions)
-                            {
-                                GetInstructionById(
-                                    CurrentInstructionNumber,
-                                    recognizer),
-                            };
+            _instructions = new Instruction[(int)_instructionSet.NumberOfInstructions];
+            
             CurrentInstructionNumber = 1;
+            _instructions[CurrentInstructionNumber - 1] = GetInstructionById(
+                CurrentInstructionNumber,
+                recognizer);
 
             Mode = mode;
             FilePaths = filePaths;

--- a/PatternPal/PatternPal.Extension/ViewModels/StepByStepInstructionsViewModel.cs
+++ b/PatternPal/PatternPal.Extension/ViewModels/StepByStepInstructionsViewModel.cs
@@ -1,5 +1,6 @@
 ﻿#region
 
+using System;
 using System.Collections.Generic;
 using System.Windows.Input;
 
@@ -85,15 +86,20 @@ namespace PatternPal.Extension.ViewModels
             }
 
             CurrentInstructionNumber++;
-            if (_currentInstructionNumber >= _instructions.Count
-                || null == _instructions[ _currentInstructionNumber ])
+            if (_currentInstructionNumber >= _instructions.Count)
             {
-                _instructions.Add(
-                    GetInstructionById(
-                        CurrentInstructionNumber - 1,
-                        Recognizer));
+                try
+                {
+                    Instruction value = _instructions[_currentInstructionNumber-1];
+                }
+                catch
+                {
+                    _instructions.Add(
+                        GetInstructionById(
+                            CurrentInstructionNumber - 1,
+                            Recognizer));
+                }
             }
-
             OnPropertyChanged(nameof( CurrentInstruction ));
             return true;
         }

--- a/PatternPal/PatternPal/Services/StepByStepService.cs
+++ b/PatternPal/PatternPal/Services/StepByStepService.cs
@@ -60,7 +60,7 @@ public class StepByStepService : Protos.StepByStepService.StepByStepServiceBase
         // information for display to the user.
         Recognizer protoRecognizer = request.Recognizers;
         IStepByStepRecognizer recognizer = RecognizerRunner.SupportedStepByStepRecognizers[ protoRecognizer ];
-        IInstruction instruction = recognizer.GenerateStepsList()[ (int)request.InstructionNumber ];
+        IInstruction instruction = recognizer.GenerateStepsList()[ (int)request.InstructionNumber -1];
         GetInstructionByIdResponse response = new()
                                               {
                                                   Instruction = new Instruction


### PR DESCRIPTION
Previously instructions were added either when the current number count was higher or equal to the instruction count up until that point (they are added when requested to the list) or whether the entry at that index was null. This last statement I have been informed by Casper is actually impossible to test with lists because it will return exceptions. So that check never worked in the first place. I have now changed it, but it involves an exception. 