### PR TITLE
BS+Ext: Base ProgessBar color on number of correct requirements

### DIFF
--- a/PatternPal/PatternPal.Extension/UserControls/ExpanderResults.xaml
+++ b/PatternPal/PatternPal.Extension/UserControls/ExpanderResults.xaml
@@ -40,6 +40,8 @@
                                     <ProgressBar x:Name="patternScore"
                                                  Height="5"
                                                  Value="{Binding Path=Score, Mode=OneWay}"
+                                                 Minimum="0"
+                                                 Maximum="100"
                                                  Width="30" Margin="10 0 0 0"
                                                  BorderBrush="{Binding ProgressBarColor}"
                                                  BorderThickness="1"
@@ -64,6 +66,8 @@
                                                             <ProgressBar x:Name="patternScore"
                                                                          Height="5"
                                                                          Value="{Binding Path=Score, Mode=OneWay}"
+                                                                         Minimum="0"
+                                                                         Maximum="100"
                                                                          Width="30" Margin="10 0 0 0"
                                                                          BorderBrush="{Binding ProgressBarColor}"
                                                                          BorderThickness="1"
@@ -71,41 +75,41 @@
                                                         </StackPanel>
                                                         <StackPanel Orientation="Horizontal" Margin="10,0,0,0">
                                                             <imaging:CrispImage Width="16"
-                                                                                Height="16"
-                                                                                HorizontalAlignment="Left"
-                                                                                Margin="0,0,10,0"
-                                                                                Moniker="{Binding MatchedNodeIcon}" />
+                                                                Height="16"
+                                                                HorizontalAlignment="Left"
+                                                                Margin="0,0,10,0"
+                                                                Moniker="{Binding MatchedNodeIcon}" />
                                                             <Label Content="{Binding MatchedNodeName}"
                                                                    MouseDoubleClick="Control_OnMouseDoubleClick" />
                                                         </StackPanel>
                                                     </StackPanel>
                                                 </Expander.Header>
-                                                    <ItemsControl Name="ResultsViewParts" ItemsSource="{Binding Children}">
-                                                        <ItemsControl.ItemTemplate>
-                                                            <DataTemplate DataType="{x:Type models:CheckResultViewModel}">
-                                                                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                                                    <imaging:CrispImage Width="24"
-                                                                                        Height="24"
-                                                                                        HorizontalAlignment="Left"
-                                                                                        Margin="0,0,10,0"
-                                                                                        Moniker="{Binding Icon}" />
-                                                                    <StackPanel Orientation="Vertical">
-                                                                        <TextBlock Text="{Binding Requirement}" Height="16"
-                                                                                   TextWrapping="NoWrap" />
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                            <imaging:CrispImage Width="16"
-                                                                                                Height="16"
-                                                                                                HorizontalAlignment="Left"
-                                                                                                Margin="0,0,10,0"
-                                                                                                Moniker="{Binding MatchedNodeIcon}" />
-                                                                            <Label Content="{Binding MatchedNodeName}"
-                                                                                   MouseDoubleClick="Control_OnMouseDoubleClick" />
-                                                                        </StackPanel>
+                                                <ItemsControl Name="ResultsViewParts" ItemsSource="{Binding Children}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate DataType="{x:Type models:CheckResultViewModel}">
+                                                            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                                                                <imaging:CrispImage Width="24"
+                                                                    Height="24"
+                                                                    HorizontalAlignment="Left"
+                                                                    Margin="0,0,10,0"
+                                                                    Moniker="{Binding Icon}" />
+                                                                <StackPanel Orientation="Vertical">
+                                                                    <TextBlock Text="{Binding Requirement}" Height="16"
+                                                                               TextWrapping="NoWrap" />
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <imaging:CrispImage Width="16"
+                                                                            Height="16"
+                                                                            HorizontalAlignment="Left"
+                                                                            Margin="0,0,10,0"
+                                                                            Moniker="{Binding MatchedNodeIcon}" />
+                                                                        <Label Content="{Binding MatchedNodeName}"
+                                                                               MouseDoubleClick="Control_OnMouseDoubleClick" />
                                                                     </StackPanel>
                                                                 </StackPanel>
-                                                            </DataTemplate>
-                                                        </ItemsControl.ItemTemplate>
-                                                    </ItemsControl>
+                                                            </StackPanel>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
                                             </Expander>
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>

--- a/PatternPal/PatternPal.Extension/ViewModels/CheckResultViewModel.cs
+++ b/PatternPal/PatternPal.Extension/ViewModels/CheckResultViewModel.cs
@@ -23,11 +23,11 @@ namespace PatternPal.Extension.ViewModels
             {
                 switch (Result.Correctness)
                 {
-                    case Result.Types.Correctness.CCorrect:
+                    case Correctness.CCorrect:
                         return KnownMonikers.StatusOK;
-                    case Result.Types.Correctness.CPartiallyCorrect:
+                    case Correctness.CPartiallyCorrect:
                         return KnownMonikers.StatusAlert;
-                    case Result.Types.Correctness.CIncorrect:
+                    case Correctness.CIncorrect:
                         return KnownMonikers.StatusWarning;
                     default:
                         return KnownMonikers.OnlineStatusUnknown;

--- a/PatternPal/PatternPal.Extension/ViewModels/PatternResultViewModel.cs
+++ b/PatternPal/PatternPal.Extension/ViewModels/PatternResultViewModel.cs
@@ -41,7 +41,7 @@ namespace PatternPal.Extension.ViewModels
         /// <summary>
         /// Completion score. 100 means all requirements are fulfilled.
         /// </summary>
-        public int Score => 100;
+        public int Score => Result.PercentageCorrectResults;
 
         /// <summary>
         /// Whether this view model is currently expanded.
@@ -56,7 +56,10 @@ namespace PatternPal.Extension.ViewModels
         /// <summary>
         /// The color of the progress bar.
         /// </summary>
-        public SolidColorBrush ProgressBarColor => Score < 40 ? Brushes.Red : Score < 80 ? Brushes.Yellow : Brushes.Green;
+        public SolidColorBrush ProgressBarColor => CalcProgressBarColor(Score);
+
+        internal static SolidColorBrush CalcProgressBarColor(
+            int score) => score < 40 ? Brushes.Red : score < 80 ? Brushes.Orange : Brushes.Green;
     }
 
     /// <summary>
@@ -118,7 +121,7 @@ namespace PatternPal.Extension.ViewModels
         /// <summary>
         /// Completion score. 100 means all requirements are fulfilled.
         /// </summary>
-        public int Score => 100;
+        public int Score => EntityResult.PercentageCorrectRequirements;
 
         /// <summary>
         /// Creates a new instance of the <see cref="EntityCheckResultViewModel"/> class.
@@ -152,6 +155,6 @@ namespace PatternPal.Extension.ViewModels
         /// <summary>
         /// The color of the progress bar.
         /// </summary>
-        public SolidColorBrush ProgressBarColor => Score < 40 ? Brushes.Red : Score < 80 ? Brushes.Yellow : Brushes.Green;
+        public SolidColorBrush ProgressBarColor => PatternResultViewModel.CalcProgressBarColor(Score);
     }
 }

--- a/PatternPal/PatternPal.Extension/Views/RecognizerView.xaml.cs
+++ b/PatternPal/PatternPal.Extension/Views/RecognizerView.xaml.cs
@@ -175,18 +175,7 @@ namespace PatternPal.Extension.Views
         private void CreateResultViewModels(
             IEnumerable< RecognizeResult > results)
         {
-            List< PatternResultViewModel > viewModels = new List< PatternResultViewModel >();
-
-            foreach (RecognizeResult result in results)
-            {
-                if (result.EntityResults.Count > 0)
-                {
-                    viewModels.Add(new PatternResultViewModel(result));
-                }
-            }
-
-            // - Change your UI information here
-            ExpanderResults.ResultsView.ItemsSource = viewModels;
+            ExpanderResults.ResultsView.ItemsSource = results.OrderByDescending(result => result.PercentageCorrectResults).Select(result => new PatternResultViewModel(result)).ToList();
         }
 
         private void SaveAllDocuments()

--- a/PatternPal/PatternPal/Services/RecognizerService.cs
+++ b/PatternPal/PatternPal/Services/RecognizerService.cs
@@ -48,8 +48,7 @@ public class RecognizerService : Protos.RecognizerService.RecognizerServiceBase
         {
             RecognizeResult rootResult = new()
                                          {
-                                             Recognizer = runResult.RecognizerType!.Value,
-                                             Feedback = "To be determined" // TODO: Generate feedback
+                                             Recognizer = runResult.RecognizerType!.Value
                                          };
 
             Dictionary< string, Result > resultsByRequirement = new();
@@ -109,6 +108,14 @@ public class RecognizerService : Protos.RecognizerService.RecognizerServiceBase
                 ? 0
                 : (int)(totalCorrectRequirements / (float)totalNrOfRequirements * 100);
 
+            rootResult.Feedback = rootResult.PercentageCorrectResults switch
+            {
+                100 => $"Well done! You have correctly implemented the {rootResult.Recognizer} design pattern.",
+                >= 75 => $"Nearly there! There are a couple requirements left you still need to implement for a correct implementation of the {rootResult.Recognizer} design pattern.",
+                >= 50 => $"It looks like you are trying to implement the {rootResult.Recognizer} design pattern, but you are still missing quite a few requirements.",
+                _ => "Not enough requirements correctly implemented"
+            };
+
             // Threshold for when a result has enough requirements correct to be shown to the user.
             const int PERCENTAGE_CORRECT_TRESHOLD = 50;
 
@@ -155,6 +162,7 @@ public class RecognizerService : Protos.RecognizerService.RecognizerServiceBase
     private IEnumerable< EntityResult > GroupResultsByRequirement(
         IOrderedEnumerable< Result > resultsOrderedByRequirements)
     {
+        // TODO: Deduplicate sub-requirements (e.g. an Any check with both options being 1a.)
         EntityResult ? entityResult = null;
         foreach (Result result in resultsOrderedByRequirements)
         {

--- a/PatternPal/PatternPal/Services/RecognizerService.cs
+++ b/PatternPal/PatternPal/Services/RecognizerService.cs
@@ -181,19 +181,7 @@ public class RecognizerService : Protos.RecognizerService.RecognizerServiceBase
                 // If `entityResult` is not null, we have found a new top-level requirement.
                 if (null != entityResult)
                 {
-                    // Get an entity from the requirements if the entity result doesn't have one yet.
-                    if (result.MatchedNode == null)
-                    {
-                        foreach (Result childResult in entityResult.Requirements)
-                        {
-                            if (childResult.MatchedNode is {Kind: MatchedNode.Types.MatchedNodeKind.MnkClass or MatchedNode.Types.MatchedNodeKind.MnkInterface})
-                            {
-                                result.MatchedNode = childResult.MatchedNode;
-                                break;
-                            }
-                        }
-                    }
-
+                    SelectMatchedNode(entityResult);
                     yield return entityResult;
                 }
 
@@ -239,7 +227,25 @@ public class RecognizerService : Protos.RecognizerService.RecognizerServiceBase
 
         if (null != entityResult)
         {
+            SelectMatchedNode(entityResult);
             yield return entityResult;
+        }
+
+        // Get an entity from the requirements if the entity result doesn't have one yet.
+        static void SelectMatchedNode(
+            EntityResult entityResult)
+        {
+            if (entityResult.MatchedNode == null)
+            {
+                foreach (Result childResult in entityResult.Requirements)
+                {
+                    if (childResult.MatchedNode is {Kind: MatchedNode.Types.MatchedNodeKind.MnkClass or MatchedNode.Types.MatchedNodeKind.MnkInterface})
+                    {
+                        entityResult.MatchedNode = childResult.MatchedNode;
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/Protos/common.proto
+++ b/Protos/common.proto
@@ -50,6 +50,9 @@ message Result {
 }
 
 // How well a requirement has been implemented.
+// IMPORTANT: There is code which relies on the fact that `C_CORRECT` is the smallest value (aside
+// from `C_UNKNOWN`), and that these results are ordered from most to least correct! New values
+// added to this enum should also use this ordering.
 enum Correctness {
     // The default value.
     C_UNKNOWN = 0;

--- a/Protos/common.proto
+++ b/Protos/common.proto
@@ -12,8 +12,11 @@ message RecognizeResult {
     // General feedback about how well a pattern is implemented.
     string feedback = 2;
 
+    // The percentage of results which are correct.
+    int32 percentage_correct_results = 3;;
+
     // The results for the individual checks which make up the recognizer.
-    repeated EntityResult entity_results = 3;
+    repeated EntityResult entity_results = 4;
 }
 
 // Result of an Entity Check.
@@ -27,8 +30,11 @@ message EntityResult {
     // How well the requirement has been implemented.
     Correctness correctness = 3;
 
+    // The percentage of requirements which are correct.
+    int32 percentage_correct_requirements = 4;
+
     // The results of the requirements of this Entity check.
-    repeated Result requirements = 4;
+    repeated Result requirements = 5;
 }
 
 // Result of one specific check inside a recognizer.

--- a/Protos/common.proto
+++ b/Protos/common.proto
@@ -24,8 +24,11 @@ message EntityResult {
     // The MatchedNode of this result, in this case an Entity.
     MatchedNode matched_node = 2;
 
+    // How well the requirement has been implemented.
+    Correctness correctness = 3;
+
     // The results of the requirements of this Entity check.
-    repeated Result requirements = 3;
+    repeated Result requirements = 4;
 }
 
 // Result of one specific check inside a recognizer.
@@ -38,21 +41,21 @@ message Result {
 
     // How well the requirement has been implemented.
     Correctness correctness = 3;
+}
 
-    // How well a requirement has been implemented.
-    enum Correctness {
-        // The default value.
-        C_UNKNOWN = 0;
+// How well a requirement has been implemented.
+enum Correctness {
+    // The default value.
+    C_UNKNOWN = 0;
 
-        // The requirement has been implemented correctly.
-        C_CORRECT = 1;
+    // The requirement has been implemented correctly.
+    C_CORRECT = 1;
 
-        // The requirement has been partially implemented.
-        C_PARTIALLY_CORRECT = 2;
+    // The requirement has been partially implemented.
+    C_PARTIALLY_CORRECT = 2;
 
-        // The requirement has not been implemented.
-        C_INCORRECT = 3;
-    }
+    // The requirement has not been implemented.
+    C_INCORRECT = 3;
 }
 
 // Node matched by a requirement.


### PR DESCRIPTION
This fixes the hard-coded progress bar color, and instead makes it dynamic again. The color is based on the percentage of requirements which are correct.

This percentage is also used to determine whether a result should be shown, with the current threshold set to `50%`.

Also determine the feedback message based on the percentage of correct requirements.