### PR TITLE
Rec+BS: Improve results scores

### DIFF
--- a/PatternPal/PatternPal.Core/Checks/NodeCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/NodeCheck.cs
@@ -8,7 +8,7 @@ public abstract class NodeCheckBase : CheckBase
     /// <summary>
     /// The sub-<see cref="ICheck"/>s of this <see cref="ICheck"/>.
     /// </summary>
-    internal IEnumerable< ICheck > SubChecks { get; }
+    public IEnumerable< ICheck > SubChecks { get; }
 
     /// <summary>
     /// Creates a new instance of <see cref="NodeCheckBase"/>.

--- a/PatternPal/PatternPal.Core/Checks/RelationCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/RelationCheck.cs
@@ -21,34 +21,10 @@ internal class RelationCheck : CheckBase
 
     /// <inheritdoc />
     public override Score PerfectScore => _perfectScore.Equals(default)
-        ? _perfectScore = PerfectScoreFromRelatedCheck(_relatedNodeCheck)
-                          + Score.CreateScore(
-                              Priority,
-                              true)
+        ? _perfectScore = Score.CreateScore(
+            Priority,
+            true)
         : _perfectScore;
-
-    /// <summary>
-    /// Gets the perfect <see cref="Score"/> of the <paramref name="relatedCheck"/>.
-    /// </summary>
-    /// <param name="relatedCheck">The related <see cref="ICheck"/>.</param>
-    /// <returns>The <see cref="ICheck.PerfectScore"/> of the <paramref name="relatedCheck"/>.</returns>
-    internal static Score PerfectScoreFromRelatedCheck(
-        ICheck relatedCheck)
-    {
-        while (true)
-        {
-            if (relatedCheck is ClassCheck or InterfaceCheck)
-            {
-                return relatedCheck.PerfectScore;
-            }
-
-            if (relatedCheck.ParentCheck == null)
-            {
-                return default;
-            }
-            relatedCheck = relatedCheck.ParentCheck;
-        }
-    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RelationCheck"/> class.
@@ -105,16 +81,16 @@ internal class RelationCheck : CheckBase
                 });
         }
 
-        return new NodeCheckResult 
-        {
-           Priority = Priority,
-           ChildrenCheckResults = results,
-           NodeCheckCollectionWrapper = true,
-           FeedbackMessage = $"Found {_relationType} relations for {node}.",
-           DependencyCount = DependencyCount,
-           MatchedNode = node,
-           Check = this,
-           CollectionKind = CheckCollectionKind.Any,
-        };
+        return new NodeCheckResult
+               {
+                   Priority = Priority,
+                   ChildrenCheckResults = results,
+                   NodeCheckCollectionWrapper = true,
+                   FeedbackMessage = $"Found {_relationType} relations for {node}.",
+                   DependencyCount = DependencyCount,
+                   MatchedNode = node,
+                   Check = this,
+                   CollectionKind = CheckCollectionKind.Any,
+               };
     }
 }

--- a/PatternPal/PatternPal.Core/Checks/TypeCheck.cs
+++ b/PatternPal/PatternPal.Core/Checks/TypeCheck.cs
@@ -19,21 +19,11 @@ internal class TypeCheck : CheckBase
         relatedCheck => 1 + relatedCheck.DependencyCount,
         _ => 0);
 
-    /// <summary>
-    /// Whether this <see cref="TypeCheck "/> is for the current <see cref="IEntity"/>.
-    /// </summary>
-    internal bool IsForCurrentEntity => _getNode.Match(
-        _ => false,
-        _ => true);
-
     /// <inheritdoc />
     public override Score PerfectScore => _perfectScore.Equals(default)
         ? _perfectScore = Score.CreateScore(
-                              Priority,
-                              true)
-                          + _getNode.Match(
-                              RelationCheck.PerfectScoreFromRelatedCheck,
-                              _ => default)
+            Priority,
+            true)
         : _perfectScore;
 
     /// <summary>
@@ -91,32 +81,32 @@ internal class TypeCheck : CheckBase
                 INode nodeToMatch = getCurrentEntity(ctx);
                 bool isMatch = node == nodeToMatch;
                 return new List< ICheckResult >
-                {
-                   new LeafCheckResult
-                   {
-                       Priority = Priority,
-                       Correct = isMatch,
-                       FeedbackMessage = isMatch
-                           ? $"Node '{node}' has correct type"
-                           : $"Node '{node}' has incorrect type, expected '{nodeToMatch}'",
-                       DependencyCount = DependencyCount,
-                       MatchedNode = nodeToMatch, //TODO is this right or should this be node?
-                       Check = this,
-                       RelatedCheck = ctx.EntityCheck
-                   }
-                };
+                       {
+                           new LeafCheckResult
+                           {
+                               Priority = Priority,
+                               Correct = isMatch,
+                               FeedbackMessage = isMatch
+                                   ? $"Node '{node}' has correct type"
+                                   : $"Node '{node}' has incorrect type, expected '{nodeToMatch}'",
+                               DependencyCount = DependencyCount,
+                               MatchedNode = nodeToMatch, //TODO is this right or should this be node?
+                               Check = this,
+                               RelatedCheck = ctx.EntityCheck
+                           }
+                       };
             });
 
         return new NodeCheckResult
-        {
-           Priority = Priority,
-           ChildrenCheckResults = results,
-           FeedbackMessage = $"Found node '{node}'",
-           DependencyCount = DependencyCount,
-           MatchedNode = node,
-           Check = this,
-           NodeCheckCollectionWrapper = true,
-           CollectionKind = CheckCollectionKind.Any
-        };
+               {
+                   Priority = Priority,
+                   ChildrenCheckResults = results,
+                   FeedbackMessage = $"Found node '{node}'",
+                   DependencyCount = DependencyCount,
+                   MatchedNode = node,
+                   Check = this,
+                   NodeCheckCollectionWrapper = true,
+                   CollectionKind = CheckCollectionKind.Any
+               };
     }
 }

--- a/PatternPal/PatternPal.Core/Recognizers/DecoratorRecognizer.cs
+++ b/PatternPal/PatternPal.Core/Recognizers/DecoratorRecognizer.cs
@@ -429,7 +429,7 @@ file class DecoratorRecognizerWithInterface : DecoratorRecognizerParent, IStepBy
     /// <inheritdoc />
     protected override MethodCheck ComponentMethod() => Method(
         Priority.Knockout, 
-        "1a. Has declared a method.");
+        "1b. Has declared a method.");
 
     /// <inheritdoc />
     protected override InterfaceCheck Component(MethodCheck componentMethod) =>

--- a/PatternPal/PatternPal/Services/RecognizerService.cs
+++ b/PatternPal/PatternPal/Services/RecognizerService.cs
@@ -98,6 +98,14 @@ public class RecognizerService : Protos.RecognizerService.RecognizerServiceBase
             foreach (EntityResult entityResult in rootResult.EntityResults)
             {
                 (int correctRequirements, int nrOfRequirements) = CalcCorrectPercentage(entityResult);
+
+                // Count requirement of the entityResult itself.
+                if (entityResult.Correctness == Correctness.CCorrect)
+                {
+                    correctRequirements++;
+                }
+                nrOfRequirements++;
+
                 totalCorrectRequirements += correctRequirements;
                 totalNrOfRequirements += nrOfRequirements;
 

--- a/PatternPal/PatternPal/Services/RecognizerService.cs
+++ b/PatternPal/PatternPal/Services/RecognizerService.cs
@@ -279,6 +279,19 @@ public class RecognizerService : Protos.RecognizerService.RecognizerServiceBase
                                     }
                                 };
 
+                if (resultToProcess.PerfectScore.Equals(default)
+                    && resultToProcess.Check is NodeCheckBase nodeCheckBase
+                    && !nodeCheckBase.SubChecks.Any()
+                    && resultToProcess is NodeCheckResult {NodeCheckCollectionWrapper: false})
+                {
+                    // ASSUME: This result belongs to a NodeCheck (e.g. a MethodCheck) with no
+                    // sub-checks. When the check has sub-checks which are incorrect, the
+                    // PerfectScore won't be 0. If the NodeCheck didn't match any nodes, the result
+                    // would contain an incorrect LeafCheckResult, resulting in a non-zero
+                    // PerfectScore.
+                    result.Correctness = Correctness.CCorrect;
+                }
+
                 if (resultToProcess.MatchedNode != null)
                 {
                     INode matchedNode = resultToProcess.MatchedNode;


### PR DESCRIPTION
Made several improvements to score calculation:
- No longer use the score of the target of a `Relation/TypeCheck`
- Handle `NodeCheck`s without sub-checks
- Check if `EntityResult` is correct