### PR TITLE
Ext: Changed title to wrapped text in viewmodels

### DIFF
--- a/PatternPal/PatternPal.Extension/ExtensionWindowControl.xaml
+++ b/PatternPal/PatternPal.Extension/ExtensionWindowControl.xaml
@@ -109,6 +109,8 @@
                         Command="{Binding BackCommand}">
                 </Button>
                 <TextBlock Text="{Binding CurrentViewModel.Title}"
+                           TextWrapping="Wrap"
+                           MaxWidth="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type StackPanel}}, Path=ActualWidth}"
                            VerticalAlignment="Center"
                            FontSize="50" />
                 <Image Source="Resources/logo.png"


### PR DESCRIPTION
Every title in all views now wraps to a max width. Especially noticeable in the SBS adapter instructions view.