### PR TITLE
SBS: Fix determining if step is correct

### DIFF
--- a/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/AdapterInstructions.Designer.cs
+++ b/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/AdapterInstructions.Designer.cs
@@ -61,7 +61,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This interface defines what fields and methods a concrete product should contain..
+        ///   Looks up a localized string similar to This interface defines some sort of behavior that we will want to adapt a class to..
         /// </summary>
         internal static string Explanation1 {
             get {
@@ -70,7 +70,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to It need to be two classes because using the factory method pattern for just one concrete product is not useful. It also needs to inherit product as the properties of a concrete product are declared there..
+        ///   Looks up a localized string similar to The client cannot use this (possibly third party) class directly because it has an incompatable interface..
         /// </summary>
         internal static string Explanation2 {
             get {
@@ -79,7 +79,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to It needs to be an abstract class and not an interface as this class has more functions than creating products. The only abstract method contains should be the factoryMethod() method which creates a product..
+        ///   Looks up a localized string similar to To be able to use the Service, we make this class to adapt it to our interface. When called, it &quot;translates&quot; the call to the Service. Its field is private, since the logic should be exposed to the other code as the general interface only. The real implementation of the Service should only be known by the adapter. .
         /// </summary>
         internal static string Explanation3 {
             get {
@@ -88,7 +88,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to It need to be two classes because every concrete product should have its own concrete creator and there are at least two concrete products. Every concrete creator inherits creator and overrides the factoryMethod() method which creates exactly one concrete product..
+        ///   Looks up a localized string similar to The client can now use the logic of the Service as if it does have a compatible interface..
         /// </summary>
         internal static string Explanation4 {
             get {
@@ -97,7 +97,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Create an interface. We refer to this interface as the Product..
+        ///   Looks up a localized string similar to Make an interface with a method. We refer to this interface as `ClientInterface`..
         /// </summary>
         internal static string Step1 {
             get {
@@ -106,7 +106,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Create two new classes which inherit the Product. We refer to these classes as Concrete Product..
+        ///   Looks up a localized string similar to Make a class that has a method. It may not inherit from ClientInterface. We refer to this class as `Service`..
         /// </summary>
         internal static string Step2 {
             get {
@@ -115,7 +115,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Create an abstract class which will contain an public abstract method which will return something of type Product. This class will be referred to as Creator..
+        ///   Looks up a localized string similar to Make a class that implements ClientInterface. Give it a private field of type Service and instantiate it. Implement the method of ClientInterface by using the method of the field. We refer to this class as `Adapter`..
         /// </summary>
         internal static string Step3 {
             get {
@@ -124,7 +124,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Create two classes which will inherit from the Creator class. Each class will have exactly one method which will create and return a different concrete product. This class will be referred to as Concrete Creator.
+        ///   Looks up a localized string similar to Make a class that creates an instance of Adapter. Give it a method that calls the method of the instantiated variable..
         /// </summary>
         internal static string Step4 {
             get {

--- a/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/AdapterInstructions.Designer.cs
+++ b/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/AdapterInstructions.Designer.cs
@@ -70,7 +70,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The client cannot use this (possibly third party) class directly because it has an incompatable interface..
+        ///   Looks up a localized string similar to The client cannot use this (possibly third party) class directly because it has an incompatible interface..
         /// </summary>
         internal static string Explanation2 {
             get {

--- a/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/AdapterInstructions.resx
+++ b/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/AdapterInstructions.resx
@@ -121,7 +121,7 @@
     <value>This interface defines some sort of behavior that we will want to adapt a class to.</value>
   </data>
   <data name="Explanation2" xml:space="preserve">
-    <value>The client cannot use this (possibly third party) class directly because it has an incompatable interface.</value>
+    <value>The client cannot use this (possibly third party) class directly because it has an incompatible interface.</value>
   </data>
   <data name="Explanation3" xml:space="preserve">
     <value>To be able to use the Service, we make this class to adapt it to our interface. When called, it "translates" the call to the Service. Its field is private, since the logic should be exposed to the other code as the general interface only. The real implementation of the Service should only be known by the adapter. </value>

--- a/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/AdapterInstructions.resx
+++ b/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/AdapterInstructions.resx
@@ -127,7 +127,7 @@
     <value>To be able to use the Service, we make this class to adapt it to our interface. When called, it "translates" the call to the Service. Its field is private, since the logic should be exposed to the other code as the general interface only. The real implementation of the Service should only be known by the adapter. </value>
   </data>
   <data name="Explanation4" xml:space="preserve">
-    <value>The client can now use the logic of the Service as if it does have a compatable interface.</value>
+    <value>The client can now use the logic of the Service as if it does have a compatible interface.</value>
   </data>
   <data name="Step1" xml:space="preserve">
     <value>Make an interface with a method. We refer to this interface as `ClientInterface`.</value>

--- a/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/BridgeInstructions.Designer.cs
+++ b/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/BridgeInstructions.Designer.cs
@@ -169,7 +169,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Make a class that implements the Implementation Interface or inherits form the Implementation Abstract Class. If it inherits from the Abstract Class it should override the abstract method. I will refer to this as the Concrete Implementation Class. .
+        ///   Looks up a localized string similar to Make a class that implements the Implementation Interface or inherits from the Implementation Abstract Class. If it inherits from the Abstract Class it should override the abstract method. I will refer to this as the Concrete Implementation Class. .
         /// </summary>
         internal static string Step5 {
             get {

--- a/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/BridgeInstructions.resx
+++ b/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/BridgeInstructions.resx
@@ -154,7 +154,7 @@
     <value>If you chose to create a field in step 2, you should create a constructor or method with a parameter with the Implementation type that sets the field of step 2 to the value of the parameter.</value>
   </data>
   <data name="Step5" xml:space="preserve">
-    <value>Make a class that implements the Implementation Interface or inherits form the Implementation Abstract Class. If it inherits from the Abstract Class it should override the abstract method. I will refer to this as the Concrete Implementation Class. </value>
+    <value>Make a class that implements the Implementation Interface or inherits from the Implementation Abstract Class. If it inherits from the Abstract Class it should override the abstract method. I will refer to this as the Concrete Implementation Class. </value>
   </data>
   <data name="Step6" xml:space="preserve">
     <value>Make a class that inherits from the Abstraction class and has a method. This class is called the Refined Abstraction Class.</value>

--- a/Protos/step_by_step.proto
+++ b/Protos/step_by_step.proto
@@ -99,5 +99,5 @@ message CheckInstructionResponse {
     bool result = 1;
 
     // Detailed result of the check of the instruction.
-    patternpal.RecognizeResult recognize_result = 2;
+    optional patternpal.RecognizeResult recognize_result = 2;
 }

--- a/docs/dev/recognizers/patterns/adapter.md
+++ b/docs/dev/recognizers/patterns/adapter.md
@@ -1,14 +1,19 @@
 # Adapter
+
 ## Introduction
+
 An adapter pattern is a design pattern that is very useful when one wants to use code that is not in the same format as the code you are currently writing. The explanation on this page is based on the definition of previous development teams, the website _refactoring guru_[^1] and the book _Design Patterns Explained_[^2].
 
 ### Context of use
+
 The adapter pattern is very useful when one wants to use code that is not in the same format as the code you are currently writing. The adapter will create an object of the used code and convert the data so that your new program can use the old object types. The old object and the new code are not even aware of the adapter. This pattern makes sure you can reuse existing subclasses without having to rewrite the old classes.
 
 ### Example of use
+
 In programming, this could be used for example when you have a program with different types of shapes, all with the coordinates of the center, and other (possibly third party) code with a particular shape with the coordinates at the top left corner. You could write an adapter that adapts the coordinates from the top left corner to the center so that the current program does not have to rewrite the old program with the corner coordinated shapes but can just use the shapes as if they were center coordinated.
 
 ## Explanation of Architecture
+
 ![UML Adapter](https://refactoring.guru/images/patterns/diagrams/adapter/structure-object-adapter-2x.png?id=03e8052e168c962d6bc369bbb13b0945)
 
 The **Service** class is the class in which the adapted code is located. This code should not be altered and is already written (possibly by a third party) and is not directly usable by the `Client`.
@@ -17,23 +22,28 @@ The **Adapter** is a class that inherits from the `Client Interface`. This class
 The **Client** is the class from which the `Adapter` object gets created.
 
 ## Requirements
+
 The priority of a requirement is noted with the (low)-(mid)-(high)-(knockout) criteria.
 
 **Service class**
+
 1. (knockout) does not inherit from the Client Interface
 2. (high) is used by the Adapter class
 
 **Client class**
+
 1. (mid) has created an object of the type Adapter
 2. (low) has used a method of the Service via the Adapter
 
 **Client interface**
+
 1. (knockout) is an interface/abstract class
 2. (knockout) is inherited/implemented by an Adapter
 3. (high) contains a method
-    1. (high) if it is an abstract class the method should be abstract
+   1. (high) if it is an abstract class the method should be abstract
 
 **Adapter**
+
 1. (knockout) inherits/implements the Client Interface
 2. (knockout) creates a Service object or gets one via the constructor
 3. (knockout) contains a private field in which the Service is stored
@@ -41,13 +51,15 @@ The priority of a requirement is noted with the (low)-(mid)-(high)-(knockout) cr
 5. (high) a method uses the Service class
 
 ## Step By Step Steps
+
 | Steps | Requirements                                                                                                                                                                                                             | Explanations                                                                                                                                                                                                                                                                                                               |
-|-------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1     | Make an interface with a method. We refer to this interface as `ClientInterface`.                                                                                                                                        | This interface defines some sort of behavior that we will want to adapt a class to.                                                                                                                                                                                                                                        |
-| 2     | Make a class that has a method. It may not inherit from ClientInterface. We refer to this class as `Service`.                                                                                                            | The client cannot use this (possibly third party) class directly because it has an incompatable interface.                                                                                                                                                                                                                 |
+| 2     | Make a class that has a method. It may not inherit from ClientInterface. We refer to this class as `Service`.                                                                                                            | The client cannot use this (possibly third party) class directly because it has an incompatible interface.                                                                                                                                                                                                                 |
 | 3     | Make a class that implements ClientInterface. Give it a private field of type Service and instantiate it. Implement the method of ClientInterface by using the method of the field. We refer to this class as `Adapter`. | To be able to use the Service, we make this class to adapt it to our interface. When called, it "translates" the call to the Service. Its field is private, since the logic should be exposed to the other code as the general interface only. The real implementation of the Service should only be known by the adapter. |
-| 4     | Make a class that creates an instance of Adapter. Give it a method that calls the method of the instantiated variable.                                                                                                   | The client can now use the logic of the Service as if it does have a compatable interface.                                                                                                                                                                                                                                 |
+| 4     | Make a class that creates an instance of Adapter. Give it a method that calls the method of the instantiated variable.                                                                                                   | The client can now use the logic of the Service as if it does have a compatible interface.                                                                                                                                                                                                                                 |
 
 ## References
+
 [^1]: Refactoring Guru, Creational Patterns - Adapter. https://refactoring.guru/design-patterns/adapter
 [^2]: A.Shalloway, J.R.Trott, Design Patterns Explained - A new perspective on Object Oriented Design (p.102 - 104). (2004)

--- a/docs/dev/recognizers/patterns/bridge.md
+++ b/docs/dev/recognizers/patterns/bridge.md
@@ -1,72 +1,84 @@
 # Bridge
+
 ## Introduction
+
 The bridge is a structural design pattern that lets you split a large class or a set of closely related classes into two separate hierarchies - abstraction and implementation - which can be developed independently of each other. The explanation on this page is based on the definition of previous development teams and the website _refactoring guru_[^1].
 
 ### Context of use
+
 The bridge design pattern is used to decouple an abstraction from its implementation, allowing them to vary independently. It is useful when you want to separate the interface or abstraction of a class from its concrete implementation. This pattern promotes loose coupling between the two, making it easier to modify or extend them individually without affecting each other.
 
 ### Example of use
-An example could be  a drawing application where we have different shapes to draw (e.g., circles, squares). The bridge pattern can be applied by separating the drawing functionality (implementation) from the shape objects (abstraction). The shape objects can have a reference to a drawing implementation object, which can be swapped without affecting the shape objects. Another example is the shape objects and their possible colors. ![Example picutre Bridge](https://refactoring.guru/images/patterns/diagrams/bridge/solution-en.png)
+
+An example could be a drawing application where we have different shapes to draw (e.g., circles, squares). The bridge pattern can be applied by separating the drawing functionality (implementation) from the shape objects (abstraction). The shape objects can have a reference to a drawing implementation object, which can be swapped without affecting the shape objects. Another example is the shape objects and their possible colors. ![Example picutre Bridge](https://refactoring.guru/images/patterns/diagrams/bridge/solution-en.png)
 
 ## Explanation of Architecture
+
 ![UML Bridge](https://refactoring.guru/images/patterns/diagrams/bridge/structure-en.png)
 
 The **Abstraction** provides a high-level control logic. It relies on the implementation object to do the actual low-level work.
 
-The **Implementation** declares the interface that's common for all concrete implementations. An abstraction can only communicate with an implementation object via methods that are declared here. 
+The **Implementation** declares the interface that's common for all concrete implementations. An abstraction can only communicate with an implementation object via methods that are declared here.
 
 The abstraction may list the same methods as the implementation but usually the abstraction decalares some complex behaviors that rely on a wide variety of primitive operations declared by the implementation.
 
 The **Concerete Implementations** contain case-specific code.
 
-The **Refined Abstractions** provide variants of control logic. Like their parent, they work with different implementations via the general implementation interface. 
+The **Refined Abstractions** provide variants of control logic. Like their parent, they work with different implementations via the general implementation interface.
 
-Usually, the **Client** is only interested in working with the abstraction. However, it's the client's job to link the abstraction object with one of the implemetation objects. 
+Usually, the **Client** is only interested in working with the abstraction. However, it's the client's job to link the abstraction object with one of the implemetation objects.
 
 ## Requirements
+
 The priority of a requirement is noted with the (low)-(mid)-(high)-(knockout) criteria.
 
 **Client class**
+
 1. (mid) uses a method in the `Abstraction` class
 2. (low) creates a `Concrete Implementation` instance
 3. (low) sets the field or property in `Abstraction`, either through
-    1. a constructor in `Abstraction` with a parameter of type `Implementation`
-    2. a method in `Abstraction` with a parameter of type `Implementation` 
-    3. setting the property
+   1. a constructor in `Abstraction` with a parameter of type `Implementation`
+   2. a method in `Abstraction` with a parameter of type `Implementation`
+   3. setting the property
 
 **Abstraction class**
+
 1. (knockout) has a private / protected field or property with the `Implementation` type
-2. (knockout) has a method 
+2. (knockout) has a method
 3. (high) there is a method that calls a method in `Implementation`
 4. (mid) has either
-    1. the property option as described in 1.
-    2. a constructor with a parameter with the `Implementation` type and that uses the field as described in 1.
-    3. a method with a parameter with the `Impelementation` type and that uses the field as described in 1.
+   1. the property option as described in 1.
+   2. a constructor with a parameter with the `Implementation` type and that uses the field as described in 1.
+   3. a method with a parameter with the `Impelementation` type and that uses the field as described in 1.
 
 **Implementation**
+
 1. (knockout) is an interface or abstract class
 2. (high) has at least one (abstract) method
 
 **Concrete Implementations**
+
 1. (knockout) is an implementation of the `Implementation` interface or inherits from the `Implementation` abstract class
 2. (high) if `Implementation` is an abstract class it should override it's abstract methods
 
 **Refined Abstraction**
+
 1. (knockout) inherits from the `Abstraction` class
 2. (high) has an method
 
 ## Step By Step Steps
+
 | Steps | Requirements                                                                                                                                                                                                                                            | Explanations                                                                                                                                                                                                                |
-|-------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1     | Make an interface or abstract class with a (if possible: abstract) method. I will refer to this as the Implementation Interface or Abstract Class.                                                                                                      | This is the interface or abstract class that is the base for concrete implementation classes.                                                                                                                               |
 | 2     | Make a class with a private or protected field or property with an Implementation type. I will refer to this class as the Abstraction Class.                                                                                                            | This class can provide a high-level control logic. It relies on the implementation object to do the actual low-level work. It stores a Concrete Implementation instance in the property or field.                           |
 | 3     | Make a method in the Abstraction class that calls the method in the Implementation Interface or Abstract Class.                                                                                                                                         | This method is used to execute the actual low-level work that is defined in a Concrete Implementation instance. It only communicates with a Concrete Implementation through the Implementation Interface or Abstract Class. |
 | 4     | If you chose to create a field in step 2, you should create a constructor or method with a parameter with the Implementation type that sets the field of step 2 to the value of the parameter.                                                          | It is time to make it possible that the field or property you created in step 2 has a value. If you created a property this will be enough, if you made a field you should make a constructor or method to do this.         |
-| 5     | Make a class that implements the Implementation Interface or inherits form the Implementation Abstract Class. If it inherits from the Abstract Class it should override the abstract method. I will refer to this as the Concrete Implementation Class. | This is a Concrete Implementation Class in which you can define the low-level work that an instance of the Abstraction Class can use.                                                                                       |
+| 5     | Make a class that implements the Implementation Interface or inherits from the Implementation Abstract Class. If it inherits from the Abstract Class it should override the abstract method. I will refer to this as the Concrete Implementation Class. | This is a Concrete Implementation Class in which you can define the low-level work that an instance of the Abstraction Class can use.                                                                                       |
 | 6     | Make a class that inherits from the Abstraction class and has a method. This class is called the Refined Abstraction Class.                                                                                                                             | This class can be used to define some more specific high-level work.                                                                                                                                                        |
 | 7     | Make a class that uses a method in the Abstraction Class. I will refer to this class as the Client Class.                                                                                                                                               | This Client Class is used to control and use the Bridge pattern.                                                                                                                                                            |
 | 8     | Let the Client Class create a Concrete Implementation instance and pass it through either a property, constructor or method to the Abstraction class.                                                                                                   | In order to complete the use of the Bridge pattern you should create a Concrete Implementation that the Abstraction class will use to execute the work.                                                                     |
 
 ## References
-[^1]: Refactoring Guru, Creational Patterns - Bridge. https://refactoring.guru/design-patterns/bridge
 
+[^1]: Refactoring Guru, Creational Patterns - Bridge. https://refactoring.guru/design-patterns/bridge


### PR DESCRIPTION
Due to some limitations in the score calculation, we unfortunately can't
rely on that to determine if the result is correct. Instead we fallback
to the old way of determining that, which is to run with prune all and
check if any results remain. This does mean that the recognizer
technically runs twice, which is inefficient. However, because a
Step-by-Step implementation is usually quite small, this doesn't really
matter.