### PR TITLE
Ext: Don't block UI during backend calls

### DIFF
--- a/PatternPal/PatternPal.Extension/Views/RecognizerView.xaml
+++ b/PatternPal/PatternPal.Extension/Views/RecognizerView.xaml
@@ -129,6 +129,19 @@
                             </Setter.Value>
                         </Setter>
                     </Trigger>
+                    <Trigger Property="IsEnabled" Value="False">
+                        <Setter Property="Background">
+                            <Setter.Value>
+                                <LinearGradientBrush StartPoint="0,0"
+                                                     EndPoint="1,1">
+                                    <GradientStop Color="#686868"
+                                                  Offset="0" />
+                                    <GradientStop Color="#707070"
+                                                  Offset="0.53" />
+                                </LinearGradientBrush>
+                            </Setter.Value>
+                        </Setter>
+                    </Trigger>
                 </Style.Triggers>
             </Style>
             <Style TargetType="ProgressBar">


### PR DESCRIPTION
This PR makes the main backend calls (`Recognize` and SBS `Check`) non-blocking, leaving the UI in a responsive state while they are running. There are perhaps a few more cases where we could make calls non-blocking, but they are not worth the effort.