### PR TITLE
SBS: changed SBS steps, corrected 'we' use, new file has pattern name

### DIFF
--- a/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/BridgeInstructions.Designer.cs
+++ b/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/BridgeInstructions.Designer.cs
@@ -133,7 +133,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Make an interface or abstract class with a (if possible: abstract) method. I will refer to this as the Implementation Interface or Abstract Class..
+        ///   Looks up a localized string similar to Make an interface or abstract class with a (if possible: abstract) method. We will refer to this as the Implementation Interface or Abstract Class..
         /// </summary>
         internal static string Step1 {
             get {
@@ -142,7 +142,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Make a class with a private or protected field or property with an Implementation type. I will refer to this class as the Abstraction Class..
+        ///   Looks up a localized string similar to Make a class with a private or protected field or property with an Implementation type. We will refer to this class as the Abstraction Class..
         /// </summary>
         internal static string Step2 {
             get {
@@ -169,7 +169,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Make a class that implements the Implementation Interface or inherits from the Implementation Abstract Class. If it inherits from the Abstract Class it should override the abstract method. I will refer to this as the Concrete Implementation Class. .
+        ///   Looks up a localized string similar to Make a class that implements the Implementation Interface or inherits from the Implementation Abstract Class. If it inherits from the Abstract Class it should override the abstract method. We will refer to this as the Concrete Implementation Class. .
         /// </summary>
         internal static string Step5 {
             get {
@@ -178,7 +178,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Make a class that inherits from the Abstraction class and has a method. This class is called the Refined Abstraction Class..
+        ///   Looks up a localized string similar to Make a class that inherits from the Abstraction class and has a method. We will refer to this as the Refined Abstraction Class..
         /// </summary>
         internal static string Step6 {
             get {
@@ -187,7 +187,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Make a class that uses a method in the Abstraction Class. I will refer to this class as the Client Class..
+        ///   Looks up a localized string similar to Make a class that uses a method in the Abstraction Class. We will refer to this class as the Client Class..
         /// </summary>
         internal static string Step7 {
             get {

--- a/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/BridgeInstructions.resx
+++ b/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/BridgeInstructions.resx
@@ -142,10 +142,10 @@
     <value>In order to complete the use of the Bridge pattern you should create a Concrete Implementation that the Abstraction class will use to execute the work. </value>
   </data>
   <data name="Step1" xml:space="preserve">
-    <value>Make an interface or abstract class with a (if possible: abstract) method. I will refer to this as the Implementation Interface or Abstract Class.</value>
+    <value>Make an interface or abstract class with a (if possible: abstract) method. We will refer to this as the Implementation Interface or Abstract Class.</value>
   </data>
   <data name="Step2" xml:space="preserve">
-    <value>Make a class with a private or protected field or property with an Implementation type. I will refer to this class as the Abstraction Class.</value>
+    <value>Make a class with a private or protected field or property with an Implementation type. We will refer to this class as the Abstraction Class.</value>
   </data>
   <data name="Step3" xml:space="preserve">
     <value>Make a method in the Abstraction class that calls the method in the Implementation Interface or Abstract Class.</value>
@@ -154,13 +154,13 @@
     <value>If you chose to create a field in step 2, you should create a constructor or method with a parameter with the Implementation type that sets the field of step 2 to the value of the parameter.</value>
   </data>
   <data name="Step5" xml:space="preserve">
-    <value>Make a class that implements the Implementation Interface or inherits from the Implementation Abstract Class. If it inherits from the Abstract Class it should override the abstract method. I will refer to this as the Concrete Implementation Class. </value>
+    <value>Make a class that implements the Implementation Interface or inherits from the Implementation Abstract Class. If it inherits from the Abstract Class it should override the abstract method. We will refer to this as the Concrete Implementation Class. </value>
   </data>
   <data name="Step6" xml:space="preserve">
-    <value>Make a class that inherits from the Abstraction class and has a method. This class is called the Refined Abstraction Class.</value>
+    <value>Make a class that inherits from the Abstraction class and has a method. We will refer to this as the Refined Abstraction Class.</value>
   </data>
   <data name="Step7" xml:space="preserve">
-    <value>Make a class that uses a method in the Abstraction Class. I will refer to this class as the Client Class.</value>
+    <value>Make a class that uses a method in the Abstraction Class. We will refer to this class as the Client Class.</value>
   </data>
   <data name="Step8" xml:space="preserve">
     <value>Let the Client Class create a Concrete Implementation instance and pass it through either a property, constructor or method to the Abstraction class.</value>

--- a/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/SingletonInstructions.Designer.cs
+++ b/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/SingletonInstructions.Designer.cs
@@ -61,7 +61,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to It needs to be an interface as all the properties of all concrete products get declared in this interface..
+        ///   Looks up a localized string similar to The constructor is private to prevent direct instantiation of the class from outside the class. This ensures that only one object is created..
         /// </summary>
         internal static string Explanation1 {
             get {
@@ -70,7 +70,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There need to be two classes because the pattern has no funtion if it only creates one concrete product. They both have to implement product because it are implementations of product.
+        ///   Looks up a localized string similar to The field is static since the Singleton should be stateless.
         /// </summary>
         internal static string Explanation2 {
             get {
@@ -79,7 +79,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The creator is an abstract class and not an interface because this class also has functions outside of creating a product. Only the method responsible for creating a product, the factoryMethod(), is abstract as this is the only function of the classes that inherit from the creator.
+        ///   Looks up a localized string similar to This method will act as a constructor. It calls the constructor and saves the object in the field of the previous step. The subsequent calls will return that same instance, instead of creating a new one. .
         /// </summary>
         internal static string Explanation3 {
             get {
@@ -88,7 +88,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Each concrete creator is a factory for one concrete product. and creating that concrete product is the only function of this class. It needs to inherit creator as the factoryMethod() method is declared there..
+        ///   Looks up a localized string similar to By how we made the Singleton, we ensure that any client accessing the field of the Singleton will get access to the same field instance..
         /// </summary>
         internal static string Explanation4 {
             get {
@@ -97,7 +97,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Create an interface. We refer to this interface as the Product..
+        ///   Looks up a localized string similar to Create a class in which the constructor is only private..
         /// </summary>
         internal static string Step1 {
             get {
@@ -106,7 +106,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Create two new classes which inherit the Product. We refer to these classes as Concrete Product..
+        ///   Looks up a localized string similar to Create a static, private field with the same type as the class..
         /// </summary>
         internal static string Step2 {
             get {
@@ -115,7 +115,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Create an abstract class which will contain an public abstract method which will return something of type Product. This class will be referred to as Creator..
+        ///   Looks up a localized string similar to Create a static, public/internal method that acts as the constructor. When called and the field from the previous step is null call the constructor, otherwise, return the field..
         /// </summary>
         internal static string Step3 {
             get {
@@ -124,7 +124,7 @@ namespace PatternPal.Core.StepByStep.Resources.Instructions {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Create two classes which will inherit from the Creator class. Each class will have exactly one method which will create and return a different concrete product. This class will be referred to as Concrete Creator.
+        ///   Looks up a localized string similar to Create a client class that calls the method from the previous step to retrieve the Singleton instance. .
         /// </summary>
         internal static string Step4 {
             get {

--- a/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/SingletonInstructions.resx
+++ b/PatternPal/PatternPal.Core/StepByStep/Resources/Instructions/SingletonInstructions.resx
@@ -130,7 +130,7 @@
     <value>By how we made the Singleton, we ensure that any client accessing the field of the Singleton will get access to the same field instance.</value>
   </data>
   <data name="Step1" xml:space="preserve">
-    <value>Create a constructor that is only private.</value>
+    <value>Create a class in which the constructor is only private.</value>
   </data>
   <data name="Step2" xml:space="preserve">
     <value>Create a static, private field with the same type as the class.</value>

--- a/PatternPal/PatternPal.Extension/ViewModels/StepByStepListViewModel.cs
+++ b/PatternPal/PatternPal.Extension/ViewModels/StepByStepListViewModel.cs
@@ -236,7 +236,7 @@ namespace PatternPal.Extension.ViewModels
             filePath =
                 Path.Combine(
                     folderPath,
-                    "NewFile.cs");
+                    SelectedInstructionSet+".cs");
             if (folderPath == string.Empty)
             {
                 return new List< string >();


### PR DESCRIPTION
The change in the singleton step 1 now informs the user to make a class in which the constructor must be private. 

The changes in the bridge now use 'we' instead of 'I' when referring to bringing it in line with the other design patterns.

Implementing a new pattern but choosing not to add it to the solution now creates a file name with the design pattern instead of 'NewFile'.