### PR TITLE
Feat: SBS continue opens more convenient initial directory in the dialog.

### DIFF
--- a/PatternPal/PatternPal.Extension/ViewModels/StepByStepListViewModel.cs
+++ b/PatternPal/PatternPal.Extension/ViewModels/StepByStepListViewModel.cs
@@ -100,6 +100,15 @@ namespace PatternPal.Extension.ViewModels
         {
             List< string > result = new List< string >();
 
+            CommonOpenFileDialog ofd2 = new CommonOpenFileDialog();
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // Obtain the currently running visual studio instance.
+            // Look for projects by selected instruction set name, if null take the first project and obtain file direcotyr.
+            DTE dte = (DTE)Package.GetGlobalService(typeof(SDTE));
+            dte.Solution.Projects.
+
             using (CommonOpenFileDialog ofd = new CommonOpenFileDialog
                    {
                        Multiselect = true,

--- a/PatternPal/PatternPal.Extension/ViewModels/StepByStepListViewModel.cs
+++ b/PatternPal/PatternPal.Extension/ViewModels/StepByStepListViewModel.cs
@@ -100,22 +100,34 @@ namespace PatternPal.Extension.ViewModels
         {
             List< string > result = new List< string >();
 
-            CommonOpenFileDialog ofd2 = new CommonOpenFileDialog();
-
+            string initialDirectory = string.Empty;
             ThreadHelper.ThrowIfNotOnUIThread();
-
-            // Obtain the currently running visual studio instance.
-            // Look for projects by selected instruction set name, if null take the first project and obtain file direcotyr.
             DTE dte = (DTE)Package.GetGlobalService(typeof(SDTE));
-            dte.Solution.Projects.
+            if (dte.Solution.IsOpen)
+            {
+                // Assume there is no project with the name as the selected design pattern 
+                initialDirectory = Path.GetDirectoryName(dte.Solution.FullName);
+
+                // Check if there is a project with the same name as selected from the dropdown
+                foreach (Project currentProject in dte.Solution.Projects)
+                {
+                    if (currentProject.Name == SelectedInstructionSet.ToString())
+                    {
+                        initialDirectory = Path.GetDirectoryName(currentProject.FullName);
+                        break;
+                    }
+                }
+            }
 
             using (CommonOpenFileDialog ofd = new CommonOpenFileDialog
                    {
                        Multiselect = true,
                        Filters = { new CommonFileDialogFilter(
                            "cs files",
-                           "cs") }
-            })
+                           "cs") },
+                       InitialDirectory = initialDirectory
+                       
+                   })
             {
                 CommonFileDialogResult res = ofd.ShowDialog();
                 if (res == CommonFileDialogResult.Ok)
@@ -128,9 +140,9 @@ namespace PatternPal.Extension.ViewModels
                 }
             }
 
-            ThreadHelper.ThrowIfNotOnUIThread();
+            //ThreadHelper.ThrowIfNotOnUIThread();
             // Obtain the currently running visual studio instance.
-            DTE dte = (DTE)Package.GetGlobalService(typeof( SDTE ));
+            //DTE dte = (DTE)Package.GetGlobalService(typeof( SDTE ));
             foreach (string file in result)
             {
                 dte.ItemOperations.OpenFile(file);


### PR DESCRIPTION
Currently, the file dialog for continue has an initial directory, the last remembered directory. This PR changes it so that it looks for projects in the opened solution. If the name of that project corresponds to the selected design pattern from the drop-down bar it uses that project's folder path as an initial directory. If there is no such project it opens the solution folder path instead that is loaded and if there is neither a project or a solution it has the same behaviour as currently.